### PR TITLE
Feature/category

### DIFF
--- a/src/main/java/org/example/baedalteam27/domain/category/controller/CategoryController.java
+++ b/src/main/java/org/example/baedalteam27/domain/category/controller/CategoryController.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("api/categories")
+@RequestMapping("/api/categories")
 public class CategoryController {
 
     private final CategoryService categoryService;
@@ -23,8 +23,8 @@ public class CategoryController {
     @PostMapping
     public ResponseEntity<CategoryResponseDto> saveCategory (
             @RequestBody CategoryRequestDto requestDto,
-            @LoginUser String role) {
-        CategoryResponseDto categoryResponseDto = categoryService.saveCategory(requestDto, role);
+            @LoginUser Long userId) {
+        CategoryResponseDto categoryResponseDto = categoryService.saveCategory(requestDto, userId);
         return ResponseEntity.ok(categoryResponseDto);
     }
 
@@ -36,21 +36,21 @@ public class CategoryController {
     }
 
     // 카테고리 수정
-    @PatchMapping("{categoryid}")
+    @PatchMapping("/{categoryid}")
     public ResponseEntity<Void> updateCategory (
             @PathVariable Long categoryid,
             @RequestBody UpdateCategoryRequestDto requestDto,
-            @LoginUser String role) {
-        categoryService.updateCategory(categoryid, requestDto, role);
+            @LoginUser Long userId) {
+        categoryService.updateCategory(categoryid, requestDto, userId);
         return ResponseEntity.ok().build();
     }
 
     // 카테고리 삭제
-    @DeleteMapping("{categoryid}")
+    @DeleteMapping("/{categoryid}")
     public ResponseEntity<Void> deleteCategory (
             @PathVariable Long categoryid,
-            @LoginUser String role) {
-        categoryService.deleteCategory(categoryid, role);
+            @LoginUser Long userId) {
+        categoryService.deleteCategory(categoryid, userId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/org/example/baedalteam27/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/org/example/baedalteam27/domain/category/repository/CategoryRepository.java
@@ -8,5 +8,7 @@ import java.util.Optional;
 
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
-    Optional<Category> findCategoryById(Long categoryid);
+    default Category findByIdOrElseThrow(Long categoryid) {
+        return findById(categoryid).orElseThrow(() -> new IllegalArgumentException("카테고리가 존재 하지 않습니다."));
+    }
 }

--- a/src/main/java/org/example/baedalteam27/domain/category/service/CategoryService.java
+++ b/src/main/java/org/example/baedalteam27/domain/category/service/CategoryService.java
@@ -55,8 +55,7 @@ public class CategoryService {
             throw new ForbiddenException("관리자 권한이 아닙니다.");
         }
 
-        Category category = categoryRepository.findCategoryById(categoryid)
-                .orElseThrow(() -> new IllegalArgumentException("카테고리가 존재하지 않습니다."));
+        Category category = categoryRepository.findByIdOrElseThrow(categoryid);
 
         // 이름 중복 검증
         if (requestDto.getName().equals(category.getName())) {
@@ -74,8 +73,7 @@ public class CategoryService {
             throw new ForbiddenException("관리자 권한이 아닙니다.");
         }
 
-        Category category = categoryRepository.findCategoryById(categoryid)
-                .orElseThrow(() -> new IllegalArgumentException("카테고리가 존재하지 않습니다."));
+        Category category = categoryRepository.findByIdOrElseThrow(categoryid);
 
         categoryRepository.delete(category);
     }

--- a/src/main/java/org/example/baedalteam27/domain/category/service/CategoryService.java
+++ b/src/main/java/org/example/baedalteam27/domain/category/service/CategoryService.java
@@ -25,7 +25,7 @@ public class CategoryService {
 
     // 카테고리 생성
     public CategoryResponseDto saveCategory(CategoryRequestDto requestDto, Long userId) {
-        User user = userRepository.findByIdOrElseThrow(userId);
+        User user = userRepository.getUserByUserId(userId);
         // 권한 확인
         if (!user.getRole().equals(UserRole.ADMIN)) {
             throw new ForbiddenException("관리자 권한이 아닙니다.");
@@ -49,7 +49,7 @@ public class CategoryService {
 
     // 카테고리 수정
     public void updateCategory(Long categoryid, UpdateCategoryRequestDto requestDto, Long userId) {
-        User user = userRepository.findByIdOrElseThrow(userId);
+        User user = userRepository.getUserByUserId(userId);
         // 권한 확인
         if (!user.getRole().equals(UserRole.ADMIN)) {
             throw new ForbiddenException("관리자 권한이 아닙니다.");
@@ -67,7 +67,7 @@ public class CategoryService {
 
     // 카테고리 삭제
     public void deleteCategory(Long categoryid, Long userId) {
-        User user = userRepository.findByIdOrElseThrow(userId);
+        User user = userRepository.getUserByUserId(userId);
         // 권한 확인
         if (!user.getRole().equals(UserRole.ADMIN)) {
             throw new ForbiddenException("관리자 권한이 아닙니다.");

--- a/src/main/java/org/example/baedalteam27/domain/category/service/CategoryService.java
+++ b/src/main/java/org/example/baedalteam27/domain/category/service/CategoryService.java
@@ -8,6 +8,9 @@ import org.example.baedalteam27.domain.category.dto.request.UpdateCategoryReques
 import org.example.baedalteam27.domain.category.entity.Category;
 import org.example.baedalteam27.domain.category.repository.CategoryRepository;
 import org.example.baedalteam27.domain.user.UserRole;
+import org.example.baedalteam27.domain.user.entitiy.User;
+import org.example.baedalteam27.domain.user.repository.UserRepository;
+import org.example.baedalteam27.global.exception.ForbiddenException;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -18,12 +21,14 @@ import java.util.stream.Collectors;
 public class CategoryService {
 
     private final CategoryRepository categoryRepository;
+    private final UserRepository userRepository;
 
     // 카테고리 생성
-    public CategoryResponseDto saveCategory(CategoryRequestDto requestDto, String role) {
+    public CategoryResponseDto saveCategory(CategoryRequestDto requestDto, Long userId) {
+        User user = userRepository.findByIdOrElseThrow(userId);
         // 권한 확인
-        if (!role.equals(UserRole.ADMIN.toString())) {
-            throw new IllegalArgumentException("관리자 권한이 아닙니다.");
+        if (!user.getRole().equals(UserRole.ADMIN)) {
+            throw new ForbiddenException("관리자 권한이 아닙니다.");
         }
 
         Category category = new Category(requestDto.getName());
@@ -43,10 +48,11 @@ public class CategoryService {
     }
 
     // 카테고리 수정
-    public void updateCategory(Long categoryid, UpdateCategoryRequestDto requestDto, String role) {
+    public void updateCategory(Long categoryid, UpdateCategoryRequestDto requestDto, Long userId) {
+        User user = userRepository.findByIdOrElseThrow(userId);
         // 권한 확인
-        if (!role.equals(UserRole.ADMIN.toString())) {
-            throw new IllegalArgumentException("관리자 권한이 아닙니다.");
+        if (!user.getRole().equals(UserRole.ADMIN)) {
+            throw new ForbiddenException("관리자 권한이 아닙니다.");
         }
 
         Category category = categoryRepository.findCategoryById(categoryid)
@@ -61,10 +67,11 @@ public class CategoryService {
     }
 
     // 카테고리 삭제
-    public void deleteCategory(Long categoryid, String role) {
+    public void deleteCategory(Long categoryid, Long userId) {
+        User user = userRepository.findByIdOrElseThrow(userId);
         // 권한 확인
-        if (!role.equals(UserRole.ADMIN.toString())) {
-            throw new IllegalArgumentException("관리자 권한이 아닙니다.");
+        if (!user.getRole().equals(UserRole.ADMIN)) {
+            throw new ForbiddenException("관리자 권한이 아닙니다.");
         }
 
         Category category = categoryRepository.findCategoryById(categoryid)

--- a/src/main/java/org/example/baedalteam27/domain/store/controller/StoreController.java
+++ b/src/main/java/org/example/baedalteam27/domain/store/controller/StoreController.java
@@ -25,13 +25,12 @@ public class StoreController {
     private final StoreService storeService;
 
     // 가게 등록
-    @PostMapping("api/categories/{categoryid}/stores")
+    @PostMapping("api/stores")
     public ResponseEntity<SaveStoreResponseDto> saveStore (
             @LoginUser Long userId,
-            @RequestBody SaveStoreRequestDto requestDto,
-            @PathVariable Long categoryid
+            @RequestBody SaveStoreRequestDto requestDto
     ) {
-        SaveStoreResponseDto saveStoreResponseDto = storeService.saveStore(userId, requestDto, categoryid);
+        SaveStoreResponseDto saveStoreResponseDto = storeService.saveStore(userId, requestDto);
         return ResponseEntity.ok(saveStoreResponseDto);
     }
 

--- a/src/main/java/org/example/baedalteam27/domain/store/controller/StoreController.java
+++ b/src/main/java/org/example/baedalteam27/domain/store/controller/StoreController.java
@@ -25,7 +25,7 @@ public class StoreController {
     private final StoreService storeService;
 
     // 가게 등록
-    @PostMapping("api/stores")
+    @PostMapping("/api/stores")
     public ResponseEntity<SaveStoreResponseDto> saveStore (
             @LoginUser Long userId,
             @RequestBody SaveStoreRequestDto requestDto
@@ -35,7 +35,7 @@ public class StoreController {
     }
 
     // 가게 전체 리스트 조회 (카테고리에 해당하는 가게명 또는 입력받은 단어가 들어가는 가게명)
-    @GetMapping("api/stores")
+    @GetMapping("/api/stores")
     public ResponseEntity<Page<StoreNameResponseDto>> findStores (
             @RequestParam(required = false) Long categoryId,
             @RequestParam(required = false) String storeName,
@@ -46,7 +46,7 @@ public class StoreController {
     }
 
     // 가게 단건 조회
-    @GetMapping("api/stores/{storeid}")
+    @GetMapping("/api/stores/{storeid}")
     public ResponseEntity<StoreResponseDto> findStore (
             @PathVariable Long storeid
     ) {
@@ -55,7 +55,7 @@ public class StoreController {
     }
 
     // 가게 수정
-    @PatchMapping("api/stores/{storeid}")
+    @PatchMapping("/api/stores/{storeid}")
     public ResponseEntity<Void> updateStore (
             @LoginUser Long userId,
             @RequestBody UpdateStoreRequestDto requestDto,
@@ -66,7 +66,7 @@ public class StoreController {
     }
 
     // 가게 폐업
-    @DeleteMapping("api/stores/{storeid}")
+    @DeleteMapping("/api/stores/{storeid}")
     public ResponseEntity<Void> deleteStore (
             @LoginUser Long userId,
             @PathVariable Long storeid

--- a/src/main/java/org/example/baedalteam27/domain/store/dto/request/SaveStoreRequestDto.java
+++ b/src/main/java/org/example/baedalteam27/domain/store/dto/request/SaveStoreRequestDto.java
@@ -12,13 +12,15 @@ public class SaveStoreRequestDto {
     private final LocalTime openTime;
     private final LocalTime closedTime;
     private final Long minOrderPrice;
+    private final Long categoryId;
 
-    public SaveStoreRequestDto(String storeName, String address, String phoneNumber, LocalTime openTime, LocalTime closedTime, Long minOrderPrice) {
+    public SaveStoreRequestDto(String storeName, String address, String phoneNumber, LocalTime openTime, LocalTime closedTime, Long minOrderPrice, Long categoryId) {
         this.storeName = storeName;
         this.address = address;
         this.phoneNumber = phoneNumber;
         this.openTime = openTime;
         this.closedTime = closedTime;
         this.minOrderPrice = minOrderPrice;
+        this.categoryId = categoryId;
     }
 }

--- a/src/main/java/org/example/baedalteam27/domain/store/dto/request/UpdateStoreRequestDto.java
+++ b/src/main/java/org/example/baedalteam27/domain/store/dto/request/UpdateStoreRequestDto.java
@@ -12,13 +12,15 @@ public class UpdateStoreRequestDto {
     private final LocalTime openTime;
     private final LocalTime closedTime;
     private final Long minOrderPrice;
+    private final Long categoryId;
 
-    public UpdateStoreRequestDto(String storeName, String address, String phoneNumber, LocalTime openTime, LocalTime closedTime, Long minOrderPrice) {
+    public UpdateStoreRequestDto(String storeName, String address, String phoneNumber, LocalTime openTime, LocalTime closedTime, Long minOrderPrice, Long categoryId) {
         this.storeName = storeName;
         this.address = address;
         this.phoneNumber = phoneNumber;
         this.openTime = openTime;
         this.closedTime = closedTime;
         this.minOrderPrice = minOrderPrice;
+        this.categoryId = categoryId;
     }
 }

--- a/src/main/java/org/example/baedalteam27/domain/store/dto/response/SaveStoreResponseDto.java
+++ b/src/main/java/org/example/baedalteam27/domain/store/dto/response/SaveStoreResponseDto.java
@@ -8,15 +8,17 @@ import java.time.LocalTime;
 public class SaveStoreResponseDto {
     private final Long id;
     private final String storeName;
+    private final String categoryName;
     private final String address;
     private final String phoneNumber;
     private final LocalTime openTime;
     private final LocalTime closedTime;
     private final Long minOrderPrice;
 
-    public SaveStoreResponseDto(Long id, String storeName, String address, String phoneNumber, LocalTime openTime, LocalTime closedTime, Long minOrderPrice) {
+    public SaveStoreResponseDto(Long id, String storeName, String categoryName, String address, String phoneNumber, LocalTime openTime, LocalTime closedTime, Long minOrderPrice) {
         this.id = id;
         this.storeName = storeName;
+        this.categoryName = categoryName;
         this.address = address;
         this.phoneNumber = phoneNumber;
         this.openTime = openTime;

--- a/src/main/java/org/example/baedalteam27/domain/store/dto/response/StoreResponseDto.java
+++ b/src/main/java/org/example/baedalteam27/domain/store/dto/response/StoreResponseDto.java
@@ -10,6 +10,7 @@ import java.util.List;
 public class StoreResponseDto {
     private final Long id;
     private final String storeName;
+    private final String categoryName;
     private final String address;
     private final String phoneNumber;
     private final LocalTime openTime;
@@ -18,9 +19,10 @@ public class StoreResponseDto {
     private final List<MenuResponseDto> menus;
 
 
-    public StoreResponseDto(Long id, String storeName, String address, String phoneNumber, LocalTime openTime, LocalTime closedTime, Long minOrderPrice, List<MenuResponseDto> menus) {
+    public StoreResponseDto(Long id, String storeName, String categoryName, String address, String phoneNumber, LocalTime openTime, LocalTime closedTime, Long minOrderPrice, List<MenuResponseDto> menus) {
         this.id = id;
         this.storeName = storeName;
+        this.categoryName = categoryName;
         this.address = address;
         this.phoneNumber = phoneNumber;
         this.openTime = openTime;

--- a/src/main/java/org/example/baedalteam27/domain/store/dto/response/StoreResponseDto.java
+++ b/src/main/java/org/example/baedalteam27/domain/store/dto/response/StoreResponseDto.java
@@ -16,10 +16,11 @@ public class StoreResponseDto {
     private final LocalTime openTime;
     private final LocalTime closedTime;
     private final Long minOrderPrice;
-    private final List<MenuResponseDto> menus;
+    private final String status;
+    private final List<MenuDto> menus;
 
 
-    public StoreResponseDto(Long id, String storeName, String categoryName, String address, String phoneNumber, LocalTime openTime, LocalTime closedTime, Long minOrderPrice, List<MenuResponseDto> menus) {
+    public StoreResponseDto(Long id, String storeName, String categoryName, String address, String phoneNumber, LocalTime openTime, LocalTime closedTime, Long minOrderPrice, String status, List<MenuDto> menus) {
         this.id = id;
         this.storeName = storeName;
         this.categoryName = categoryName;
@@ -28,6 +29,7 @@ public class StoreResponseDto {
         this.openTime = openTime;
         this.closedTime = closedTime;
         this.minOrderPrice = minOrderPrice;
+        this.status = status;
         this.menus = menus;
     }
 }

--- a/src/main/java/org/example/baedalteam27/domain/store/entity/Store.java
+++ b/src/main/java/org/example/baedalteam27/domain/store/entity/Store.java
@@ -67,9 +67,6 @@ public class Store {
     @OneToMany(mappedBy = "store")
     private List<Menu> menus = new ArrayList<>();  // menus null 값 방지 초기화
 
-    // 영업상태
-    private Status status;
-
     // 파라미터가 달라지는 여러 생성자를 위해 빌더 적용
     @Builder
     public Store (String storeName,
@@ -79,9 +76,9 @@ public class Store {
                   LocalTime closedTime,
                   Long minOrderPrice,
                   User user,
-                  Category category,
-                  List<Menu> menus,
-                  Status status) {
+                  Category category
+                  List<Menu> menus
+                  ) {
         this.storeName = storeName;
         this.address = address;
         this.phoneNumber = phoneNumber;
@@ -91,7 +88,6 @@ public class Store {
         this.user =user;
         this.category = category;
         this.menus = menus;
-        this.status = status;
     }
 
     // 가게 수정

--- a/src/main/java/org/example/baedalteam27/domain/store/entity/Store.java
+++ b/src/main/java/org/example/baedalteam27/domain/store/entity/Store.java
@@ -100,7 +100,8 @@ public class Store {
                        String phoneNumber,
                        LocalTime openTime,
                        LocalTime closedTime,
-                       Long minOrderPrice
+                       Long minOrderPrice,
+                       Category category
     ) {
         this.storeName = storeName;
         this.address = address;
@@ -108,6 +109,7 @@ public class Store {
         this.openTime = openTime;
         this.closedTime = closedTime;
         this.minOrderPrice = minOrderPrice;
+        this.category = category;
     }
 
     // 가게 운영 상태

--- a/src/main/java/org/example/baedalteam27/domain/store/repository/StoreRepository.java
+++ b/src/main/java/org/example/baedalteam27/domain/store/repository/StoreRepository.java
@@ -4,11 +4,9 @@ import org.example.baedalteam27.domain.store.entity.Store;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
-@Repository
 public interface StoreRepository extends JpaRepository<Store, Long> {
     // 가게가 폐업 상태가 아닌 가게만 조회, storeName 단어가 들어간 가게들 조회
     Page<Store> findByStoreNameContainingAndIsDeletedFalse(String storeName, Pageable pageable);

--- a/src/main/java/org/example/baedalteam27/domain/store/repository/StoreRepository.java
+++ b/src/main/java/org/example/baedalteam27/domain/store/repository/StoreRepository.java
@@ -20,4 +20,8 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
     int countByUserIdAndIsDeletedFalse(Long userId);
 
     Page<Store> findByIsDeletedFalse(Pageable pageable);
+
+    default Store findByIdOrElseThrow(Long storeId) {
+        return findById(storeId).orElseThrow(() -> new IllegalArgumentException("가게가 존재하지 않습니다."));
+    }
 }

--- a/src/main/java/org/example/baedalteam27/domain/store/service/StoreService.java
+++ b/src/main/java/org/example/baedalteam27/domain/store/service/StoreService.java
@@ -33,12 +33,12 @@ public class StoreService {
 
 
     // 가게 등록
-    public SaveStoreResponseDto saveStore(Long userId, SaveStoreRequestDto requestDto, Long categoryId) {
+    public SaveStoreResponseDto saveStore(Long userId, SaveStoreRequestDto requestDto) {
         // 유저, 카테고리 조회
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자가 존재하지 않습니다."));
 
-        Category category = categoryRepository.findById(categoryId)
+        Category category = categoryRepository.findById(requestDto.getCategoryId())
                 .orElseThrow(() -> new IllegalArgumentException("카테고리가 존재하지 않습니다."));
 
         // 유저가 사장님 권한을 가졌는지 검증
@@ -142,6 +142,10 @@ public class StoreService {
             throw new IllegalArgumentException("해당 가게에 대한 수정 권한이 없습니다.");
         }
 
+        // 카테고리 조회
+        Category category = categoryRepository.findById(requestDto.getCategoryId())
+                .orElseThrow(() -> new IllegalArgumentException("카테고리가 존재하지 않습니다."));
+
         // 가게 수정된 정보 저장
         store.update(
                 requestDto.getStoreName(),
@@ -149,7 +153,8 @@ public class StoreService {
                 requestDto.getPhoneNumber(),
                 requestDto.getOpenTime(),
                 requestDto.getClosedTime(),
-                requestDto.getMinOrderPrice()
+                requestDto.getMinOrderPrice(),
+                category
         );
     }
 

--- a/src/main/java/org/example/baedalteam27/domain/store/service/StoreService.java
+++ b/src/main/java/org/example/baedalteam27/domain/store/service/StoreService.java
@@ -10,15 +10,18 @@ import org.example.baedalteam27.domain.store.dto.response.SaveStoreResponseDto;
 import org.example.baedalteam27.domain.store.dto.response.StoreNameResponseDto;
 import org.example.baedalteam27.domain.store.dto.response.StoreResponseDto;
 import org.example.baedalteam27.domain.store.entity.Store;
+import org.example.baedalteam27.domain.store.enums.Status;
 import org.example.baedalteam27.domain.store.repository.StoreRepository;
 import org.example.baedalteam27.domain.user.UserRole;
 import org.example.baedalteam27.domain.user.entitiy.User;
 import org.example.baedalteam27.domain.user.repository.UserRepository;
+import org.example.baedalteam27.global.exception.ForbiddenException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.awt.*;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -35,15 +38,13 @@ public class StoreService {
     // 가게 등록
     public SaveStoreResponseDto saveStore(Long userId, SaveStoreRequestDto requestDto) {
         // 유저, 카테고리 조회
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("사용자가 존재하지 않습니다."));
+        User user = userRepository.findByIdOrElseThrow(userId);
 
-        Category category = categoryRepository.findById(requestDto.getCategoryId())
-                .orElseThrow(() -> new IllegalArgumentException("카테고리가 존재하지 않습니다."));
+        Category category = categoryRepository.findByIdOrElseThrow(requestDto.getCategoryId());
 
         // 유저가 사장님 권한을 가졌는지 검증
         if (!user.getRole().equals(UserRole.OWNER)) {
-            throw new IllegalArgumentException("가게를 등록할 권한이 없습니다.");
+            throw new ForbiddenException("가게를 등록할 권한이 없습니다.");
         }
 
         // 소요한 가게가 3개 이하인지 검증
@@ -114,9 +115,12 @@ public class StoreService {
                 .orElseThrow(() -> new IllegalArgumentException("해당 이름의 가게를 찾을 수 없습니다."));
 
         // 메뉴를 MenuResponseDto에 담고 리스트로 변환 (N+1 문제 해결 예정)
-        List<MenuResponseDto> menuResponseDtoList = store.getMenus().stream()
-                .map(menu -> new MenuResponseDto(menu.getName(), menu.getPrice(), menu.getDescription()))
+        List<MenuDto> menuDtoList = store.getMenus().stream()
+                .map(menu -> new MenuDto(menu.getName(), menu.getPrice(), menu.getDescription(), menu.getIsSoldOut()))
                 .collect(Collectors.toList());
+
+        // 가게 상태 조회
+        Status currentStatus = store.getCurrentStatus(LocalTime.now());
 
         return new StoreResponseDto(
                 store.getId(),
@@ -127,7 +131,8 @@ public class StoreService {
                 store.getOpenTime(),
                 store.getClosedTime(),
                 store.getMinOrderPrice(),
-                menuResponseDtoList);
+                currentStatus.toString(),
+                menuDtoList);
     }
 
     // 가게 수정
@@ -135,17 +140,15 @@ public class StoreService {
     public void updateStore(Long userId, UpdateStoreRequestDto requestDto, Long storeId) {
 
         // 가게 찾기
-        Store store = storeRepository.findById(storeId)
-                .orElseThrow(() -> new IllegalArgumentException("가게가 존재하지 않습니다."));
+        Store store = storeRepository.findByIdOrElseThrow(storeId);
 
         // 유저가 가게를 등록한 유저인지 검증
         if (!userId.equals(store.getUser().getId())) {
-            throw new IllegalArgumentException("해당 가게에 대한 수정 권한이 없습니다.");
+            throw new ForbiddenException("해당 가게에 대한 수정 권한이 없습니다.");
         }
 
         // 카테고리 조회
-        Category category = categoryRepository.findById(requestDto.getCategoryId())
-                .orElseThrow(() -> new IllegalArgumentException("카테고리가 존재하지 않습니다."));
+        Category category = categoryRepository.findByIdOrElseThrow(requestDto.getCategoryId());
 
         // 가게 수정된 정보 저장
         store.update(
@@ -161,20 +164,18 @@ public class StoreService {
 
     // 가게 폐업
     public void deleteStore(Long userId, Long storeId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("사용자가 존재하지 않습니다."));
+        User user = userRepository.findByIdOrElseThrow(userId);
 
         // 유저가 사장님 권한을 가졌는지 검증
         if (!user.getRole().equals(UserRole.OWNER)) {
-            throw new IllegalArgumentException("가게 사장님이 아닙니다.");
+            throw new ForbiddenException("가게 사장님이 아닙니다.");
         }
 
-        Store store = storeRepository.findById(storeId)
-                .orElseThrow(() -> new IllegalArgumentException("가게가 존재하지 않습니다."));
+        Store store = storeRepository.findByIdOrElseThrow(storeId);
 
         // 유저가 가게를 등록한 유저인지 검증
         if (!user.getId().equals(store.getUser().getId())) {
-            throw new IllegalArgumentException("해당 가게에 대한 삭제 권한이 없습니다.");
+            throw new ForbiddenException("해당 가게에 대한 삭제 권한이 없습니다.");
         }
 
         // 폐업한 가게를 다시 폐업하려고 할 때

--- a/src/main/java/org/example/baedalteam27/domain/store/service/StoreService.java
+++ b/src/main/java/org/example/baedalteam27/domain/store/service/StoreService.java
@@ -38,7 +38,7 @@ public class StoreService {
     // 가게 등록
     public SaveStoreResponseDto saveStore(Long userId, SaveStoreRequestDto requestDto) {
         // 유저, 카테고리 조회
-        User user = userRepository.findByIdOrElseThrow(userId);
+        User user = userRepository.getUserByUserId(userId);
 
         Category category = categoryRepository.findByIdOrElseThrow(requestDto.getCategoryId());
 
@@ -164,7 +164,7 @@ public class StoreService {
 
     // 가게 폐업
     public void deleteStore(Long userId, Long storeId) {
-        User user = userRepository.findByIdOrElseThrow(userId);
+        User user = userRepository.getUserByUserId(userId);
 
         // 유저가 사장님 권한을 가졌는지 검증
         if (!user.getRole().equals(UserRole.OWNER)) {

--- a/src/main/java/org/example/baedalteam27/domain/store/service/StoreService.java
+++ b/src/main/java/org/example/baedalteam27/domain/store/service/StoreService.java
@@ -104,14 +104,13 @@ public class StoreService {
 
     // 가게 단건 조회
     public StoreResponseDto findStore(Long storeId) {
-        Store store; // 변수 선언
         // 필수값 검증
         if (storeId == null) {
             throw new IllegalArgumentException("가게 번호는 필수!");
         }
 
         // 전체에서 가게 조회
-        store = storeRepository.findByIdAndIsDeletedFalse(storeId)
+        Store store = storeRepository.findByIdAndIsDeletedFalse(storeId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 이름의 가게를 찾을 수 없습니다."));
 
         // 메뉴를 MenuResponseDto에 담고 리스트로 변환 (N+1 문제 해결 예정)

--- a/src/main/java/org/example/baedalteam27/domain/store/service/StoreService.java
+++ b/src/main/java/org/example/baedalteam27/domain/store/service/StoreService.java
@@ -69,6 +69,7 @@ public class StoreService {
         return new SaveStoreResponseDto(
                 saveStore.getId(),
                 saveStore.getStoreName(),
+                category.getName(),
                 saveStore.getAddress(),
                 saveStore.getPhoneNumber(),
                 saveStore.getOpenTime(),
@@ -121,6 +122,7 @@ public class StoreService {
         return new StoreResponseDto(
                 store.getId(),
                 store.getStoreName(),
+                store.getCategory().getName(),
                 store.getAddress(),
                 store.getPhoneNumber(),
                 store.getOpenTime(),

--- a/src/main/java/org/example/baedalteam27/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/example/baedalteam27/domain/user/repository/UserRepository.java
@@ -8,4 +8,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByEmail(String email);
 	boolean existsByEmail(String email);
+
+	default User findByIdOrElseThrow (Long userId) {
+		return findById(userId).orElseThrow(() -> new IllegalArgumentException("유저가 존재하지 않습니다."));
+	}
 }

--- a/src/main/java/org/example/baedalteam27/global/exception/ErrorResponse.java
+++ b/src/main/java/org/example/baedalteam27/global/exception/ErrorResponse.java
@@ -1,0 +1,14 @@
+package org.example.baedalteam27.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorResponse {
+    private int status;
+    private String message;
+
+    public ErrorResponse (int status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/src/main/java/org/example/baedalteam27/global/exception/ForbiddenException.java
+++ b/src/main/java/org/example/baedalteam27/global/exception/ForbiddenException.java
@@ -1,0 +1,7 @@
+package org.example.baedalteam27.global.exception;
+
+public class ForbiddenException extends RuntimeException{
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/example/baedalteam27/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/baedalteam27/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,22 @@
+package org.example.baedalteam27.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handlerIllegalArgumentException (IllegalArgumentException e) {
+        ErrorResponse errorResponse = new ErrorResponse(500, e.getMessage());
+        return ResponseEntity.internalServerError().body(errorResponse);
+    }
+
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ErrorResponse> handlerForbiddenException (ForbiddenException e) {
+        ErrorResponse errorResponse = new ErrorResponse(403, e.getMessage());
+        return ResponseEntity.internalServerError().body(errorResponse);
+        }
+}


### PR DESCRIPTION
> PR 생성 시 아래 항목을 채워주세요.
>
>
> **제목 예시:** `feat : Pull request template 작성`
>
> (✅ 작성 후 이 안내 문구는 삭제해주세요)
>

---

## 🔎 작업 내용

- 

---

## 🛠️ 변경 사항

- 가게 등록 시 @PathVariable [에서 받아오던 categoryId 를 dto 에서 받도록 변경
- 가게 등록 및 수정 시 categoryId 를 dto 에서 받도록 변경
- 가게 등록 및 저장 시 responseDto에 categoryName 추가
- URL Path 수정 및 파라미터 값 수정
- exceptionHandler 에서 exception 관리
- 공통된 findById 메서드 예외처리
---

## 🧩 트러블 슈팅

- 카테고리 삭제 시 외래키를 가지고 있는 가게와의 연관관계 문제

---

## 🧯 해결해야 할 문제

- 카테고리를 엔티티로 만들고 DB에서 따로 관리하다 보니 가게가 카테고리의 외래키를 갖고 있어 카테고리 삭제 시 에러 발생!
   1. 유지 보수 측면 에서 enum으로 관리 하는게 더 좋나?   -> enum으로 관리하면 개발자만 카테고리를 관리할 수 있다. (코드를 직접 건드려야 한다.)
  
   2. cascade 사용하면 해당 카테고리의 모든 가게가 삭제되니까 X
   
   3. Softdelete 사용하자니 필드 추가, storeserivce 에서 조건 로직 추가…. 별로임
   
   4. 외래키를 해제하여 연관 관계를 끊고, 부모 엔티티를 삭제 하고나서 다시 자식 엔티티에 외래키 설정.  -> 데이터 정합성 문제 발생 (권장 X)
   
   5. On delete set null 사용? 카테고리 삭제 시 가게가 가지고 있는 categoryId를 null 로 변경. ->  카테고리 삭제 시 해당 가게들은 전부 categoryId 가 null 값이 되어 조회 불가. ->  가게 수정 해서 categoryId 주입!  -> 어노테이션이나 따로 하는 방법이 없고 DB에서 직접 쿼리를 작성해서 on delete set null 을 적용 해 주어야 한다. 따라서 null 값인 데이터를 다룬다는게 이상하고, 다른 사람이 코드를 봤을 때 분석하기 힘듦…. 

---

## 📌 참고 사항

- 기타 공유하고 싶은 정보나 참고한 문서(링크 등)가 있다면 작성해주세요.

---

### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인