### PR TITLE
feat : 토큰 리이슈 및 필터 구현

### DIFF
--- a/src/main/java/org/example/baedalteam27/domain/auth/dto/LoginResponseDto.java
+++ b/src/main/java/org/example/baedalteam27/domain/auth/dto/LoginResponseDto.java
@@ -1,0 +1,11 @@
+package org.example.baedalteam27.domain.auth.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class LoginResponseDto {
+	private final String accessToken;
+	private final String refreshToken;
+}

--- a/src/main/java/org/example/baedalteam27/domain/auth/dto/MailCheckResponseDto.java
+++ b/src/main/java/org/example/baedalteam27/domain/auth/dto/MailCheckResponseDto.java
@@ -1,6 +1,5 @@
 package org.example.baedalteam27.domain.auth.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/org/example/baedalteam27/domain/auth/dto/PasswordChangeResponseDto.java
+++ b/src/main/java/org/example/baedalteam27/domain/auth/dto/PasswordChangeResponseDto.java
@@ -2,7 +2,6 @@ package org.example.baedalteam27.domain.auth.dto;
 
 import lombok.Getter;
 
-import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 
 @Getter

--- a/src/main/java/org/example/baedalteam27/domain/auth/service/AuthService.java
+++ b/src/main/java/org/example/baedalteam27/domain/auth/service/AuthService.java
@@ -9,6 +9,7 @@ import org.example.baedalteam27.global.config.PasswordEncoder;
 import org.example.baedalteam27.global.jwt.JwtProvider;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 
@@ -22,6 +23,7 @@ public class AuthService {
 	private final RedisTemplate<String, String> redisTemplate;
 
 	// 회원가입
+	@Transactional
 	public void signup(SignupRequestDto dto) {
 		if (!isValidEmail(dto.getEmail()) || !isValidPassword(dto.getPassword())) {
 			throw new IllegalArgumentException("이메일 또는 비밀번호 형식이 유효하지 않습니다.");
@@ -41,6 +43,7 @@ public class AuthService {
 	}
 
 	// 로그인
+
 	public String login(LoginRequestDto dto) {
 		User user = userRepository.findByEmail(dto.getEmail())
 			.orElseThrow(() -> new IllegalArgumentException("아이디 또는 비밀번호가 일치하지 않습니다."));
@@ -57,6 +60,7 @@ public class AuthService {
 	}
 
 	// 회원 탈퇴
+	@Transactional
 	public void withdraw(Long userId, String rawPassword) {
 		User user = userRepository.getUserByUserId(userId);
 
@@ -82,6 +86,7 @@ public class AuthService {
 	}
 
 	// 비밀번호 변경
+	@Transactional
 	public PasswordChangeResponseDto passwordChange(Long userId, PasswordChangeRequestDto dto) {
 		User user = userRepository.getUserByUserId(userId);
 
@@ -99,6 +104,7 @@ public class AuthService {
 	}
 
 	// 로그아웃
+	@Transactional
 	public void logout(String token, Long userId) {
 		if (Boolean.TRUE.equals(redisTemplate.hasKey(token))) {
 			throw new IllegalStateException("이미 로그아웃된 사용자입니다.");

--- a/src/main/java/org/example/baedalteam27/domain/user/entitiy/User.java
+++ b/src/main/java/org/example/baedalteam27/domain/user/entitiy/User.java
@@ -1,25 +1,16 @@
 package org.example.baedalteam27.domain.user.entitiy;
 
-import java.time.LocalDateTime;
-
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.example.baedalteam27.domain.user.UserRole;
 import org.example.baedalteam27.global.entity.BaseEntity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-import lombok.Getter;
-import lombok.Setter;
-
 @Entity
 @Getter
-@Setter
-@Table(name = "users") // H2 예약어 방지용
+@NoArgsConstructor
+@Table(name = "users")
 public class User extends BaseEntity {
 
 	@Id
@@ -34,11 +25,29 @@ public class User extends BaseEntity {
 
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
-	private UserRole role;      // 역할 (USER, OWNER, ADMIN)
+	private UserRole role;
 
-	private String provider;     // "kakao", "naver" 등
-	private String providerId;   // 소셜 ID
+	private String provider;
+
+	private String providerId;
 
 	private Boolean isDeleted = false;
 
+	@Builder
+	public User(String email, String password, UserRole role, String provider, String providerId) {
+		this.email = email;
+		this.password = password;
+		this.role = role;
+		this.provider = provider;
+		this.providerId = providerId;
+		this.isDeleted = false;
+	}
+
+	public void changePassword(String encodedPassword) {
+		this.password = encodedPassword;
+	}
+
+	public void withdraw() {
+		this.isDeleted = true;
+	}
 }

--- a/src/main/java/org/example/baedalteam27/global/jwt/JwtAuthFilter.java
+++ b/src/main/java/org/example/baedalteam27/global/jwt/JwtAuthFilter.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Set;
 
 @Component
 @RequiredArgsConstructor
@@ -18,19 +19,42 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 	private final JwtProvider jwtProvider;
 	private final RedisTemplate<String, String> redisTemplate;
 
+	private static final Set<String> PUBLIC_URIS = Set.of(
+		"/api/auth/signup",
+		"/api/auth/login",
+		"/api/auth/mail-check",
+		"/api/auth/reissue"
+	);
+
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
 		throws ServletException, IOException {
 
-		String token = resolveToken(request);
+		String uri = request.getRequestURI();
 
-		if (token != null) {
-			// 로그아웃된 토큰이면 요청 차단
-			if (Boolean.TRUE.equals(redisTemplate.hasKey(token))) {
-				response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-				response.getWriter().write("로그아웃된 토큰입니다.");
-				return;
-			}
+		// 인증이 필요 없는 URI는 필터 통과
+		if (PUBLIC_URIS.contains(uri)) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+
+		String token = resolveToken(request);
+		if (token == null) {
+			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+			response.getWriter().write("Authorization 헤더가 없습니다.");
+			return;
+		}
+
+		if (Boolean.TRUE.equals(redisTemplate.hasKey(token))) {
+			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+			response.getWriter().write("로그아웃된 토큰입니다.");
+			return;
+		}
+
+		if (!jwtProvider.validateToken(token)) {
+			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+			response.getWriter().write("유효하지 않은 토큰입니다.");
+			return;
 		}
 
 		filterChain.doFilter(request, response);

--- a/src/main/java/org/example/baedalteam27/global/jwt/JwtProvider.java
+++ b/src/main/java/org/example/baedalteam27/global/jwt/JwtProvider.java
@@ -21,6 +21,7 @@ public class JwtProvider {
 	private String secret;
 
 	private final long EXPIRATION_TIME = 1000 * 60 * 60; // 1시간
+	private final long REFRESH_TIME = 1000 * 60 * 60 * 24 * 7; // 7일
 
 	@PostConstruct
 	public void init() {
@@ -28,7 +29,7 @@ public class JwtProvider {
 		this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
 	}
 
-	public String createToken(Long userId, String role) {
+	public String createAccessToken(Long userId, String role) {
 		return Jwts.builder()
 			.setSubject(userId.toString())
 			.claim("role", role)
@@ -37,6 +38,37 @@ public class JwtProvider {
 			.signWith(key)
 			.compact();
 	}
+
+	public String createRefreshToken() {
+		return Jwts.builder()
+			.setIssuedAt(new Date())
+			.setExpiration(new Date(System.currentTimeMillis() + REFRESH_TIME))
+			.signWith(key)
+			.compact();
+	}
+
+	public boolean validateToken(String token) {
+		try {
+			Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+			return true;
+		} catch (JwtException | IllegalArgumentException e) {
+			return false;
+		}
+	}
+
+	public Long extractUserIdAllowExpired(String token) {
+		try {
+			return Long.parseLong(Jwts.parserBuilder()
+				.setSigningKey(key)
+				.build()
+				.parseClaimsJws(token.replace("Bearer ", ""))
+				.getBody()
+				.getSubject());
+		} catch (ExpiredJwtException e) {
+			return Long.parseLong(e.getClaims().getSubject()); // 만료된 토큰이라도 claims 접근 가능
+		}
+	}
+
 
 	public Long getUserIdFromToken(String token) {
 		return Long.parseLong(parseClaims(token).getBody().getSubject());


### PR DESCRIPTION

---

## 🔎 작업 내용

- 토큰 리이슈 구현
- User entity refactoring
- Filter에서 정해진 URL아니면 걸러지게 변경
- 안쓰는 import 삭제

---

## 🛠️ 변경 사항

---

## 🧩 트러블 슈팅

---

## 🧯 해결해야 할 문제

---

## 📌 참고 사항

- JwtAuthFilter에 가셔서 로그인하지 않은 유저도 사용가능한 API 주소들 입력해주셔야 사용가능합니다.
---

### 🙏 코드 리뷰 전 확인 체크리스트

- [x]  불필요한 콘솔 로그, 주석 제거
- [x]  커밋 메시지 컨벤션 준수 (`type : `)
- [x]  기능 정상 동작 확인