### PR TITLE
test : AuthService 단위테스트 구현

### DIFF
--- a/src/main/java/org/example/baedalteam27/domain/auth/service/AuthService.java
+++ b/src/main/java/org/example/baedalteam27/domain/auth/service/AuthService.java
@@ -5,6 +5,8 @@ import org.example.baedalteam27.domain.auth.dto.*;
 import org.example.baedalteam27.domain.user.entitiy.User;
 import org.example.baedalteam27.domain.user.repository.UserRepository;
 import org.example.baedalteam27.global.config.PasswordEncoder;
+import org.example.baedalteam27.global.exception.CustomException;
+import org.example.baedalteam27.global.exception.ErrorCode;
 import org.example.baedalteam27.global.jwt.JwtProvider;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -26,35 +28,38 @@ public class AuthService {
 	// 회원가입
 	@Transactional
 	public void signup(SignupRequestDto dto) {
-		if (!isValidEmail(dto.getEmail()) || !isValidPassword(dto.getPassword())) {
-			throw new IllegalArgumentException("이메일 또는 비밀번호 형식이 유효하지 않습니다.");
+		if (!isValidEmail(dto.getEmail())) {
+			throw new CustomException(ErrorCode.INVALID_EMAIL_FORMAT);
+		}
+
+		if (!isValidPassword(dto.getPassword())) {
+			throw new CustomException(ErrorCode.INVALID_PASSWORD_FORMAT);
 		}
 
 		if (userRepository.existsByEmail(dto.getEmail())) {
-			throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
+			throw new CustomException(ErrorCode.EMAIL_ALREADY_EXISTS);
 		}
 
 		User user = User.builder()
-			.email(dto.getEmail())
-			.password(passwordEncoder.encode(dto.getPassword()))
-			.role(dto.getRole())
-			.build();
+				.email(dto.getEmail())
+				.password(passwordEncoder.encode(dto.getPassword()))
+				.role(dto.getRole())
+				.build();
 
 		userRepository.save(user);
 	}
 
 	// 로그인
-
 	public String login(LoginRequestDto dto) {
 		User user = userRepository.findByEmail(dto.getEmail())
-			.orElseThrow(() -> new IllegalArgumentException("아이디 또는 비밀번호가 일치하지 않습니다."));
+				.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
 		if (Boolean.TRUE.equals(user.getIsDeleted())) {
-			throw new IllegalArgumentException("이미 탈퇴한 사용자입니다.");
+			throw new CustomException(ErrorCode.ALREADY_WITHDRAWN);
 		}
 
 		if (!passwordEncoder.matches(dto.getPassword(), user.getPassword())) {
-			throw new IllegalArgumentException("아이디 또는 비밀번호가 일치하지 않습니다.");
+			throw new CustomException(ErrorCode.INVALID_PASSWORD);
 		}
 
 		return jwtProvider.createAccessToken(user.getId(), user.getRole().name());
@@ -66,7 +71,7 @@ public class AuthService {
 		User user = userRepository.getUserByUserId(userId);
 
 		if (!passwordEncoder.matches(rawPassword, user.getPassword())) {
-			throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+			throw new CustomException(ErrorCode.INVALID_PASSWORD);
 		}
 
 		user.withdraw();
@@ -75,7 +80,7 @@ public class AuthService {
 	// 이메일 중복 체크
 	public MailCheckResponseDto mailCheck(MailCheckRequestDto dto) {
 		if (!isValidEmail(dto.getEmail())) {
-			throw new IllegalArgumentException("올바른 이메일 형식이 아닙니다.");
+			throw new CustomException(ErrorCode.INVALID_EMAIL_FORMAT);
 		}
 
 		boolean exists = userRepository.existsByEmail(dto.getEmail());
@@ -92,11 +97,11 @@ public class AuthService {
 		User user = userRepository.getUserByUserId(userId);
 
 		if (!passwordEncoder.matches(dto.getNowPassword(), user.getPassword())) {
-			throw new IllegalArgumentException("현재 비밀번호와 일치하지 않습니다.");
+			throw new CustomException(ErrorCode.INVALID_PASSWORD);
 		}
 
 		if (!isValidPassword(dto.getNewPassword())) {
-			throw new IllegalArgumentException("새 비밀번호 형식이 유효하지 않습니다.");
+			throw new CustomException(ErrorCode.INVALID_PASSWORD_FORMAT);
 		}
 
 		user.changePassword(passwordEncoder.encode(dto.getNewPassword()));
@@ -108,20 +113,21 @@ public class AuthService {
 	@Transactional
 	public void logout(String token, Long userId) {
 		if (Boolean.TRUE.equals(redisTemplate.hasKey(token))) {
-			throw new IllegalStateException("이미 로그아웃된 사용자입니다.");
+			throw new CustomException(ErrorCode.ALREADY_LOGOUT);
 		}
 
 		long expiration = jwtProvider.getExpiration(token);
 		redisTemplate.opsForValue().set(token, "logout", Duration.ofMillis(expiration));
 	}
 
+	// 토큰 재발급
 	public Map<String, String> reissueToken(String refreshToken, Long userId) {
 		if (!jwtProvider.validateToken(refreshToken)) {
-			throw new IllegalArgumentException("유효하지 않은 리프레시 토큰입니다.");
+			throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
 		}
 
 		User user = userRepository.findById(userId)
-			.orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+				.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
 		String newAccessToken = jwtProvider.createAccessToken(user.getId(), user.getRole().name());
 		String newRefreshToken = jwtProvider.createRefreshToken();
@@ -141,9 +147,9 @@ public class AuthService {
 	// 비밀번호 유효성 체크
 	private boolean isValidPassword(String pw) {
 		return pw.length() >= 8 &&
-			pw.matches(".*[A-Z].*") &&
-			pw.matches(".*[a-z].*") &&
-			pw.matches(".*[0-9].*") &&
-			pw.matches(".*[!@#$%^&*()].*");
+				pw.matches(".*[A-Z].*") &&
+				pw.matches(".*[a-z].*") &&
+				pw.matches(".*[0-9].*") &&
+				pw.matches(".*[!@#$%^&*()].*");
 	}
 }

--- a/src/main/java/org/example/baedalteam27/global/exception/CustomException.java
+++ b/src/main/java/org/example/baedalteam27/global/exception/CustomException.java
@@ -1,0 +1,13 @@
+package org.example.baedalteam27.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/org/example/baedalteam27/global/exception/ErrorCode.java
+++ b/src/main/java/org/example/baedalteam27/global/exception/ErrorCode.java
@@ -1,0 +1,30 @@
+package org.example.baedalteam27.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    // 400 Bad Request
+    INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "USER_001", "올바른 이메일 형식이 아닙니다."),
+    INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "USER_002", "비밀번호 형식이 유효하지 않습니다."),
+    EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "USER_003", "이미 존재하는 이메일입니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "USER_004", "비밀번호가 일치하지 않습니다."),
+
+    // 401 Unauthorized
+    UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "USER_005", "인증되지 않은 사용자입니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_001", "유효하지 않은 리프레시 토큰입니다."),
+
+    // 404 Not Found
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_006", "사용자를 찾을 수 없습니다."),
+
+    // 409 Conflict
+    ALREADY_WITHDRAWN(HttpStatus.CONFLICT, "USER_007", "이미 탈퇴한 사용자입니다."),
+    ALREADY_LOGOUT(HttpStatus.CONFLICT, "USER_008", "이미 로그아웃된 사용자입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/org/example/baedalteam27/global/exception/ErrorResponse.java
+++ b/src/main/java/org/example/baedalteam27/global/exception/ErrorResponse.java
@@ -4,11 +4,11 @@ import lombok.Getter;
 
 @Getter
 public class ErrorResponse {
-    private int status;
-    private String message;
+    private final String code;
+    private final String message;
 
-    public ErrorResponse (int status, String message) {
-        this.status = status;
-        this.message = message;
+    public ErrorResponse(ErrorCode errorCode) {
+        this.code = errorCode.getCode();
+        this.message = errorCode.getMessage();
     }
 }

--- a/src/main/java/org/example/baedalteam27/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/baedalteam27/global/exception/GlobalExceptionHandler.java
@@ -5,18 +5,16 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ErrorResponse> handlerIllegalArgumentException (IllegalArgumentException e) {
-        ErrorResponse errorResponse = new ErrorResponse(400, e.getMessage());
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
-    }
-
-    @ExceptionHandler(ForbiddenException.class)
-    public ResponseEntity<ErrorResponse> handlerForbiddenException(ForbiddenException e) {
-        ErrorResponse errorResponse = new ErrorResponse(403, e.getMessage());
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(errorResponse);
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException ex) {
+        ErrorCode errorCode = ex.getErrorCode();
+        ErrorResponse response = new ErrorResponse(errorCode);
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(response);
     }
 }

--- a/src/test/java/org/example/baedalteam27/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/org/example/baedalteam27/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,309 @@
+package org.example.baedalteam27.domain.auth.service;
+
+import org.example.baedalteam27.domain.auth.dto.*;
+import org.example.baedalteam27.domain.user.UserRole;
+import org.example.baedalteam27.domain.user.entitiy.User;
+import org.example.baedalteam27.domain.user.repository.UserRepository;
+import org.example.baedalteam27.global.config.PasswordEncoder;
+import org.example.baedalteam27.global.jwt.JwtProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Test
+    void signup() {
+        //주어질 Dto 생성
+        SignupRequestDto request = new SignupRequestDto("test@example.com", "Password1!", UserRole.USER);
+
+        // 중복된 이메일로 가입된 유저 없는지 확인
+        given(userRepository.existsByEmail(request.getEmail())).willReturn(false);
+
+        // 암호화된 비밀번호 부여
+        given(passwordEncoder.encode(request.getPassword())).willReturn("encodedPassword");
+
+        // when
+        authService.signup(request);
+
+        // then
+        then(userRepository).should(times(1)).save(any(User.class));
+    }
+
+    @Test
+    void login_성공() {
+        // given
+        LoginRequestDto request = new LoginRequestDto("test@example.com", "Password1!");
+
+        User fakeUser = User.builder()
+                .email(request.getEmail())
+                .password("encodedPassword") // DB에 저장된 비밀번호는 암호화된 상태여야 함
+                .role(UserRole.USER)
+                .build();
+
+        // id가 builder에서 빠져있어서 id 강제주입
+        ReflectionTestUtils.setField(fakeUser, "id", 1L);
+
+        // 이메일로 유저를 찾으면 fakeUser를 리턴
+        given(userRepository.findByEmail(request.getEmail())).willReturn(Optional.of(fakeUser));
+
+        // 입력한 비밀번호와 저장된 비밀번호를 비교했을 때 일치한다고 가정
+        given(passwordEncoder.matches(request.getPassword(), fakeUser.getPassword())).willReturn(true);
+
+        // 토큰을 만들어줬다고 가정
+        given(jwtProvider.createAccessToken(fakeUser.getId(), fakeUser.getRole().name())).willReturn("mocked-access-token");
+
+        // when
+        String token = authService.login(request);
+
+        // then
+        assertNotNull(token); // 토큰은 null이 아니어야 한다
+        assertEquals("mocked-access-token", token); // 우리가 가짜로 만들어준 토큰과 같아야 한다
+    }
+
+    @Test
+    void login_실패_비밀번호_불일치() {
+
+        // 위에와 똑같이 회원가입 User 생성
+        LoginRequestDto request = new LoginRequestDto("test@example.com", "Password1!");
+
+        User fakeUser = User.builder()
+                .email(request.getEmail())
+                .password("encodedPassword")
+                .role(UserRole.USER)
+                .build();
+
+        ReflectionTestUtils.setField(fakeUser, "id", 1L);
+
+        given(userRepository.findByEmail(request.getEmail())).willReturn(Optional.of(fakeUser));
+
+        // 비밀번호 불일치하게 given
+        given(passwordEncoder.matches(request.getPassword(), fakeUser.getPassword())).willReturn(false);
+
+        // 비밀번호가 틀리므로 IllegalArgumentException return
+        assertThrows(IllegalArgumentException.class, () -> authService.login(request));
+
+    }
+
+    @Test
+    void login_실패_이미_탈퇴한_유저() {
+
+        LoginRequestDto request = new LoginRequestDto("test@example.com", "Password1!");
+
+        User fakeUser = User.builder()
+                .email(request.getEmail())
+                .password("encodedPassword")
+                .role(UserRole.USER)
+                .build();
+
+        ReflectionTestUtils.setField(fakeUser, "id", 1L);
+        ReflectionTestUtils.setField(fakeUser,"isDeleted", true);
+
+        assertThrows(IllegalArgumentException.class, () -> authService.login(request));
+    }
+
+    @Test
+    void login_실패_이메일_불일치() {
+
+        LoginRequestDto request = new LoginRequestDto("test@example.com", "Password1!");
+
+        User fakeUser = User.builder()
+                .email("wrong@example.com")
+                .password("EncodedPassword")
+                .role(UserRole.USER)
+                .build();
+
+        ReflectionTestUtils.setField(fakeUser, "id", 1L);
+
+        assertThrows(IllegalArgumentException.class, () -> authService.login(request));
+
+    }
+
+
+    @Test
+    void withdraw_성공() {
+        // given
+        Long userId = 1L;
+        String rawPassword = "Password1!";
+
+        User fakeUser = User.builder()
+                .email("test@example.com")
+                .password("encodedPassword")
+                .role(UserRole.USER)
+                .build();
+        ReflectionTestUtils.setField(fakeUser, "id", userId);
+
+        given(userRepository.getUserByUserId(userId)).willReturn(fakeUser);
+        given(passwordEncoder.matches(rawPassword, fakeUser.getPassword())).willReturn(true);
+
+        // when
+        authService.withdraw(userId, rawPassword);
+
+        // then
+        assertTrue(fakeUser.getIsDeleted()); // 탈퇴 상태여야 한다
+    }
+
+
+    @Test
+    void mailCheck_성공_중복X() {
+        // given
+        MailCheckRequestDto request = new MailCheckRequestDto("test@example.com");
+        given(userRepository.existsByEmail(request.getEmail())).willReturn(false); // 이메일 중복 없음
+
+        // when
+        MailCheckResponseDto response = authService.mailCheck(request);
+
+        // then
+        assertTrue(response.isAvailable()); // 사용 가능해야 함
+        assertEquals("사용 가능한 이메일입니다.", response.getMessage());
+    }
+
+    @Test
+    void passwordChange_성공() {
+        // given
+        Long userId = 1L;
+        String nowPassword = "Password1!";
+        String newPassword = "NewPassword1!";
+
+        User fakeUser = User.builder()
+                .email("test@example.com")
+                .password("encodedPassword")
+                .role(UserRole.USER)
+                .build();
+        ReflectionTestUtils.setField(fakeUser, "id", userId);
+
+        given(userRepository.getUserByUserId(userId)).willReturn(fakeUser);
+        given(passwordEncoder.matches(nowPassword, fakeUser.getPassword())).willReturn(true);
+        given(passwordEncoder.encode(newPassword)).willReturn("newEncodedPassword");
+
+        PasswordChangeRequestDto requestDto = new PasswordChangeRequestDto(nowPassword, newPassword);
+
+        // when
+        PasswordChangeResponseDto response = authService.passwordChange(userId, requestDto);
+
+        // then
+        assertEquals("비밀번호가 성공적으로 변경되었습니다.", response.getMessage());
+    }
+    @Test
+    void passwordChange_실패_현재비밀번호불일치() {
+        // given
+        Long userId = 1L;
+        PasswordChangeRequestDto requestDto = new PasswordChangeRequestDto("WrongNowPassword", "NewPassword1!");
+
+        User fakeUser = User.builder()
+                .email("test@example.com")
+                .password("encodedPassword")
+                .role(UserRole.USER)
+                .build();
+        ReflectionTestUtils.setField(fakeUser, "id", userId);
+
+        given(userRepository.getUserByUserId(userId)).willReturn(fakeUser);
+        given(passwordEncoder.matches(requestDto.getNowPassword(), fakeUser.getPassword())).willReturn(false);
+
+        // when & then
+        assertThrows(IllegalArgumentException.class, () -> authService.passwordChange(userId, requestDto));
+    }
+
+    @Test
+    void logout_성공() {
+        // given
+        String token = "access-token";
+        Long userId = 1L;
+
+        given(redisTemplate.hasKey(token)).willReturn(false);
+        given(jwtProvider.getExpiration(token)).willReturn(60000L);
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+        // when
+        authService.logout(token, userId);
+
+        // then
+        then(redisTemplate).should(times(1)).opsForValue();
+        then(valueOperations).should(times(1)).set(token, "logout", Duration.ofMillis(60000L));
+    }
+    @Test
+    void logout_실패_이미로그아웃() {
+        // given
+        String token = "access-token";
+        Long userId = 1L;
+
+        given(redisTemplate.hasKey(token)).willReturn(true);
+
+        // when & then
+        assertThrows(IllegalStateException.class, () -> authService.logout(token, userId));
+    }
+
+    @Test
+    void reissueToken_성공() {
+        // given
+        String refreshToken = "refresh-token";
+        Long userId = 1L;
+
+        User fakeUser = User.builder()
+                .email("test@example.com")
+                .password("encodedPassword")
+                .role(UserRole.USER)
+                .build();
+        ReflectionTestUtils.setField(fakeUser, "id", userId);
+
+        given(jwtProvider.validateToken(refreshToken)).willReturn(true);
+        given(userRepository.findById(userId)).willReturn(Optional.of(fakeUser));
+        given(jwtProvider.createAccessToken(userId, fakeUser.getRole().name())).willReturn("new-access-token");
+        given(jwtProvider.createRefreshToken()).willReturn("new-refresh-token");
+
+        // when
+        Map<String, String> tokens = authService.reissueToken(refreshToken, userId);
+
+        // then
+        assertEquals("new-access-token", tokens.get("accessToken"));
+        assertEquals("new-refresh-token", tokens.get("refreshToken"));
+    }
+
+    @Test
+    void reissueToken_실패_유효하지않은리프레시토큰() {
+        // given
+        String refreshToken = "invalid-refresh-token";
+        Long userId = 1L;
+
+        given(jwtProvider.validateToken(refreshToken)).willReturn(false);
+
+        // when & then
+        assertThrows(IllegalArgumentException.class, () -> authService.reissueToken(refreshToken, userId));
+    }
+
+}

--- a/src/test/java/org/example/baedalteam27/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/org/example/baedalteam27/domain/auth/service/AuthServiceTest.java
@@ -5,6 +5,8 @@ import org.example.baedalteam27.domain.user.UserRole;
 import org.example.baedalteam27.domain.user.entitiy.User;
 import org.example.baedalteam27.domain.user.repository.UserRepository;
 import org.example.baedalteam27.global.config.PasswordEncoder;
+import org.example.baedalteam27.global.exception.CustomException;
+import org.example.baedalteam27.global.exception.ErrorCode;
 import org.example.baedalteam27.global.jwt.JwtProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,19 +14,18 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
-
-import org.springframework.data.redis.core.ValueOperations;
-import org.springframework.test.util.ReflectionTestUtils;
+import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
@@ -49,118 +50,84 @@ class AuthServiceTest {
 
     @Test
     void signup() {
-        //주어질 Dto 생성
         SignupRequestDto request = new SignupRequestDto("test@example.com", "Password1!", UserRole.USER);
 
-        // 중복된 이메일로 가입된 유저 없는지 확인
         given(userRepository.existsByEmail(request.getEmail())).willReturn(false);
-
-        // 암호화된 비밀번호 부여
         given(passwordEncoder.encode(request.getPassword())).willReturn("encodedPassword");
 
-        // when
         authService.signup(request);
 
-        // then
         then(userRepository).should(times(1)).save(any(User.class));
     }
 
     @Test
     void login_성공() {
-        // given
         LoginRequestDto request = new LoginRequestDto("test@example.com", "Password1!");
-
         User fakeUser = User.builder()
                 .email(request.getEmail())
-                .password("encodedPassword") // DB에 저장된 비밀번호는 암호화된 상태여야 함
+                .password("encodedPassword")
                 .role(UserRole.USER)
                 .build();
-
-        // id가 builder에서 빠져있어서 id 강제주입
         ReflectionTestUtils.setField(fakeUser, "id", 1L);
 
-        // 이메일로 유저를 찾으면 fakeUser를 리턴
         given(userRepository.findByEmail(request.getEmail())).willReturn(Optional.of(fakeUser));
-
-        // 입력한 비밀번호와 저장된 비밀번호를 비교했을 때 일치한다고 가정
         given(passwordEncoder.matches(request.getPassword(), fakeUser.getPassword())).willReturn(true);
-
-        // 토큰을 만들어줬다고 가정
         given(jwtProvider.createAccessToken(fakeUser.getId(), fakeUser.getRole().name())).willReturn("mocked-access-token");
 
-        // when
         String token = authService.login(request);
 
-        // then
-        assertNotNull(token); // 토큰은 null이 아니어야 한다
-        assertEquals("mocked-access-token", token); // 우리가 가짜로 만들어준 토큰과 같아야 한다
+        assertNotNull(token);
+        assertEquals("mocked-access-token", token);
     }
 
     @Test
-    void login_실패_비밀번호_불일치() {
-
-        // 위에와 똑같이 회원가입 User 생성
+    void login_실패_비밀번호불일치() {
         LoginRequestDto request = new LoginRequestDto("test@example.com", "Password1!");
-
         User fakeUser = User.builder()
                 .email(request.getEmail())
                 .password("encodedPassword")
                 .role(UserRole.USER)
                 .build();
-
         ReflectionTestUtils.setField(fakeUser, "id", 1L);
 
         given(userRepository.findByEmail(request.getEmail())).willReturn(Optional.of(fakeUser));
-
-        // 비밀번호 불일치하게 given
         given(passwordEncoder.matches(request.getPassword(), fakeUser.getPassword())).willReturn(false);
 
-        // 비밀번호가 틀리므로 IllegalArgumentException return
-        assertThrows(IllegalArgumentException.class, () -> authService.login(request));
-
+        CustomException exception = assertThrows(CustomException.class, () -> authService.login(request));
+        assertEquals(ErrorCode.INVALID_PASSWORD, exception.getErrorCode());
     }
 
     @Test
-    void login_실패_이미_탈퇴한_유저() {
-
+    void login_실패_이미탈퇴한유저() {
         LoginRequestDto request = new LoginRequestDto("test@example.com", "Password1!");
-
         User fakeUser = User.builder()
                 .email(request.getEmail())
                 .password("encodedPassword")
                 .role(UserRole.USER)
                 .build();
-
         ReflectionTestUtils.setField(fakeUser, "id", 1L);
-        ReflectionTestUtils.setField(fakeUser,"isDeleted", true);
+        ReflectionTestUtils.setField(fakeUser, "isDeleted", true);
 
-        assertThrows(IllegalArgumentException.class, () -> authService.login(request));
+        given(userRepository.findByEmail(request.getEmail())).willReturn(Optional.of(fakeUser));
+
+        CustomException exception = assertThrows(CustomException.class, () -> authService.login(request));
+        assertEquals(ErrorCode.ALREADY_WITHDRAWN, exception.getErrorCode());
     }
 
     @Test
-    void login_실패_이메일_불일치() {
-
+    void login_실패_이메일불일치() {
         LoginRequestDto request = new LoginRequestDto("test@example.com", "Password1!");
 
-        User fakeUser = User.builder()
-                .email("wrong@example.com")
-                .password("EncodedPassword")
-                .role(UserRole.USER)
-                .build();
+        given(userRepository.findByEmail(request.getEmail())).willReturn(Optional.empty());
 
-        ReflectionTestUtils.setField(fakeUser, "id", 1L);
-
-        assertThrows(IllegalArgumentException.class, () -> authService.login(request));
-
+        CustomException exception = assertThrows(CustomException.class, () -> authService.login(request));
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
     }
-
 
     @Test
     void withdraw_성공() {
-        // given
         Long userId = 1L;
         String rawPassword = "Password1!";
-
         User fakeUser = User.builder()
                 .email("test@example.com")
                 .password("encodedPassword")
@@ -171,31 +138,42 @@ class AuthServiceTest {
         given(userRepository.getUserByUserId(userId)).willReturn(fakeUser);
         given(passwordEncoder.matches(rawPassword, fakeUser.getPassword())).willReturn(true);
 
-        // when
         authService.withdraw(userId, rawPassword);
 
-        // then
-        assertTrue(fakeUser.getIsDeleted()); // 탈퇴 상태여야 한다
+        assertTrue(fakeUser.getIsDeleted());
     }
 
+    @Test
+    void withdraw_실패_비밀번호불일치() {
+        Long userId = 1L;
+        String rawPassword = "WrongPassword";
+        User fakeUser = User.builder()
+                .email("test@example.com")
+                .password("encodedPassword")
+                .role(UserRole.USER)
+                .build();
+        ReflectionTestUtils.setField(fakeUser, "id", userId);
+
+        given(userRepository.getUserByUserId(userId)).willReturn(fakeUser);
+        given(passwordEncoder.matches(rawPassword, fakeUser.getPassword())).willReturn(false);
+
+        CustomException exception = assertThrows(CustomException.class, () -> authService.withdraw(userId, rawPassword));
+        assertEquals(ErrorCode.INVALID_PASSWORD, exception.getErrorCode());
+    }
 
     @Test
     void mailCheck_성공_중복X() {
-        // given
         MailCheckRequestDto request = new MailCheckRequestDto("test@example.com");
-        given(userRepository.existsByEmail(request.getEmail())).willReturn(false); // 이메일 중복 없음
+        given(userRepository.existsByEmail(request.getEmail())).willReturn(false);
 
-        // when
         MailCheckResponseDto response = authService.mailCheck(request);
 
-        // then
-        assertTrue(response.isAvailable()); // 사용 가능해야 함
+        assertTrue(response.isAvailable());
         assertEquals("사용 가능한 이메일입니다.", response.getMessage());
     }
 
     @Test
     void passwordChange_성공() {
-        // given
         Long userId = 1L;
         String nowPassword = "Password1!";
         String newPassword = "NewPassword1!";
@@ -213,15 +191,13 @@ class AuthServiceTest {
 
         PasswordChangeRequestDto requestDto = new PasswordChangeRequestDto(nowPassword, newPassword);
 
-        // when
         PasswordChangeResponseDto response = authService.passwordChange(userId, requestDto);
 
-        // then
         assertEquals("비밀번호가 성공적으로 변경되었습니다.", response.getMessage());
     }
+
     @Test
     void passwordChange_실패_현재비밀번호불일치() {
-        // given
         Long userId = 1L;
         PasswordChangeRequestDto requestDto = new PasswordChangeRequestDto("WrongNowPassword", "NewPassword1!");
 
@@ -235,13 +211,12 @@ class AuthServiceTest {
         given(userRepository.getUserByUserId(userId)).willReturn(fakeUser);
         given(passwordEncoder.matches(requestDto.getNowPassword(), fakeUser.getPassword())).willReturn(false);
 
-        // when & then
-        assertThrows(IllegalArgumentException.class, () -> authService.passwordChange(userId, requestDto));
+        CustomException exception = assertThrows(CustomException.class, () -> authService.passwordChange(userId, requestDto));
+        assertEquals(ErrorCode.INVALID_PASSWORD, exception.getErrorCode());
     }
 
     @Test
     void logout_성공() {
-        // given
         String token = "access-token";
         Long userId = 1L;
 
@@ -249,28 +224,25 @@ class AuthServiceTest {
         given(jwtProvider.getExpiration(token)).willReturn(60000L);
         given(redisTemplate.opsForValue()).willReturn(valueOperations);
 
-        // when
         authService.logout(token, userId);
 
-        // then
         then(redisTemplate).should(times(1)).opsForValue();
         then(valueOperations).should(times(1)).set(token, "logout", Duration.ofMillis(60000L));
     }
+
     @Test
     void logout_실패_이미로그아웃() {
-        // given
         String token = "access-token";
         Long userId = 1L;
 
         given(redisTemplate.hasKey(token)).willReturn(true);
 
-        // when & then
-        assertThrows(IllegalStateException.class, () -> authService.logout(token, userId));
+        CustomException exception = assertThrows(CustomException.class, () -> authService.logout(token, userId));
+        assertEquals(ErrorCode.ALREADY_LOGOUT, exception.getErrorCode());
     }
 
     @Test
     void reissueToken_성공() {
-        // given
         String refreshToken = "refresh-token";
         Long userId = 1L;
 
@@ -286,24 +258,20 @@ class AuthServiceTest {
         given(jwtProvider.createAccessToken(userId, fakeUser.getRole().name())).willReturn("new-access-token");
         given(jwtProvider.createRefreshToken()).willReturn("new-refresh-token");
 
-        // when
         Map<String, String> tokens = authService.reissueToken(refreshToken, userId);
 
-        // then
         assertEquals("new-access-token", tokens.get("accessToken"));
         assertEquals("new-refresh-token", tokens.get("refreshToken"));
     }
 
     @Test
     void reissueToken_실패_유효하지않은리프레시토큰() {
-        // given
         String refreshToken = "invalid-refresh-token";
         Long userId = 1L;
 
         given(jwtProvider.validateToken(refreshToken)).willReturn(false);
 
-        // when & then
-        assertThrows(IllegalArgumentException.class, () -> authService.reissueToken(refreshToken, userId));
+        CustomException exception = assertThrows(CustomException.class, () -> authService.reissueToken(refreshToken, userId));
+        assertEquals(ErrorCode.INVALID_REFRESH_TOKEN, exception.getErrorCode());
     }
-
 }


### PR DESCRIPTION
---

## 🔎 작업 내용

- AuthService에 있는 모든 메서드 단위테스트 구현
- ENUM으로 예외처리 구현
---

## 🛠️ 변경 사항

---

## 🧩 트러블 슈팅

- 
---

## 🧯 해결해야 할 문제

- 기능은 동작하지만 리팩토링이나 논의가 필요한 부분을 적어주세요.
- 예)D
    - `UserController`에서 비즈니스 로직 일부 처리 → 서비스로 이전 고려 필요

---

## 📌 참고 사항

- 객체 불러올때 @Mock 적용시 속이 빈 객체로 바뀌어 버려서 Return하는 모든값이 Null로 바뀜
- given.willReturn()으로 값을 정해줘야함
- @Spy는 실제 객체를 가져와서 작동가능
- 각자의 오류 ENUM에 담아서 CustomExcetion으로 관리

---

### 🙏 코드 리뷰 전 확인 체크리스트

- [x]  불필요한 콘솔 로그, 주석 제거
- [x]  커밋 메시지 컨벤션 준수 (`type : `)
- [x]  기능 정상 동작 확인