### PR TITLE
Feat: CategoryService 및 StoreService test 코드 구현

### DIFF
--- a/src/main/java/org/example/baedalteam27/domain/category/service/CategoryService.java
+++ b/src/main/java/org/example/baedalteam27/domain/category/service/CategoryService.java
@@ -10,7 +10,8 @@ import org.example.baedalteam27.domain.category.repository.CategoryRepository;
 import org.example.baedalteam27.domain.user.UserRole;
 import org.example.baedalteam27.domain.user.entitiy.User;
 import org.example.baedalteam27.domain.user.repository.UserRepository;
-import org.example.baedalteam27.global.exception.ForbiddenException;
+import org.example.baedalteam27.global.exception.CustomException;
+import org.example.baedalteam27.global.exception.ErrorCode;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,7 +31,7 @@ public class CategoryService {
         User user = userRepository.getUserByUserId(userId);
         // 권한 확인
         if (!user.getRole().equals(UserRole.ADMIN)) {
-            throw new ForbiddenException("관리자 권한이 아닙니다.");
+            throw new CustomException(ErrorCode.NOT_ADMIN);
         }
 
         Category category = new Category(requestDto.getName());
@@ -56,14 +57,14 @@ public class CategoryService {
         User user = userRepository.getUserByUserId(userId);
         // 권한 확인
         if (!user.getRole().equals(UserRole.ADMIN)) {
-            throw new ForbiddenException("관리자 권한이 아닙니다.");
+            throw new CustomException(ErrorCode.NOT_ADMIN);
         }
 
         Category category = categoryRepository.findByIdAndIsDeletedFalseOrElseThrow(categoryid);
 
         // 이름 중복 검증
         if (requestDto.getName().equals(category.getName())) {
-            throw new IllegalArgumentException("중복된 이름입니다.");
+            throw new CustomException(ErrorCode.CATEGORY_NAME_ALREADY_EXISTS);
         }
 
         category.update(requestDto.getName());
@@ -75,7 +76,7 @@ public class CategoryService {
         User user = userRepository.getUserByUserId(userId);
         // 권한 확인
         if (!user.getRole().equals(UserRole.ADMIN)) {
-            throw new ForbiddenException("관리자 권한이 아닙니다.");
+            throw new CustomException(ErrorCode.NOT_ADMIN);
         }
 
         Category category = categoryRepository.findByIdAndIsDeletedFalseOrElseThrow(categoryid);

--- a/src/main/java/org/example/baedalteam27/domain/store/service/StoreService.java
+++ b/src/main/java/org/example/baedalteam27/domain/store/service/StoreService.java
@@ -48,7 +48,7 @@ public class StoreService {
             throw new ForbiddenException("가게를 등록할 권한이 없습니다.");
         }
 
-        // 소요한 가게가 3개 이하인지 검증
+        // 소유한 가게가 3개 이하인지 검증
         int storeCount = storeRepository.countByUserIdAndIsDeletedFalse(userId);
         if (storeCount >= 3) {
             throw new IllegalArgumentException("가게는 최대 3개까지만 등록할 수 있습니다.");

--- a/src/main/java/org/example/baedalteam27/domain/store/service/StoreService.java
+++ b/src/main/java/org/example/baedalteam27/domain/store/service/StoreService.java
@@ -16,7 +16,8 @@ import org.example.baedalteam27.domain.store.repository.StoreRepository;
 import org.example.baedalteam27.domain.user.UserRole;
 import org.example.baedalteam27.domain.user.entitiy.User;
 import org.example.baedalteam27.domain.user.repository.UserRepository;
-import org.example.baedalteam27.global.exception.ForbiddenException;
+import org.example.baedalteam27.global.exception.CustomException;
+import org.example.baedalteam27.global.exception.ErrorCode;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -45,13 +46,13 @@ public class StoreService {
 
         // 유저가 사장님 권한을 가졌는지 검증
         if (!user.getRole().equals(UserRole.OWNER)) {
-            throw new ForbiddenException("가게를 등록할 권한이 없습니다.");
+            throw new CustomException(ErrorCode.NOT_OWNER);
         }
 
         // 소유한 가게가 3개 이하인지 검증
         int storeCount = storeRepository.countByUserIdAndIsDeletedFalse(userId);
         if (storeCount >= 3) {
-            throw new IllegalArgumentException("가게는 최대 3개까지만 등록할 수 있습니다.");
+            throw new CustomException(ErrorCode.STORE_LIMIT_EXCEPTION);
         }
 
         Store store = Store.builder()
@@ -84,7 +85,7 @@ public class StoreService {
     public Page<StoreNameResponseDto> findStores(Long categoryId, String storeName, Pageable pageable) {
         // 둘 다 입력 했을 때 예외처리
         if (categoryId != null && storeName != null) {
-            throw new IllegalArgumentException("카테고리 또는 가게명 중 하나만 입력! 또는 둘 다 입력X");
+            throw new CustomException(ErrorCode.INVALID_PARAMETER);
         }
 
         // 입력받은 단어가 들어가는 가게명
@@ -108,7 +109,7 @@ public class StoreService {
     public StoreResponseDto findStore(Long storeId) {
         // 필수값 검증
         if (storeId == null) {
-            throw new IllegalArgumentException("가게 번호는 필수!");
+            throw new CustomException(ErrorCode.NULL_STORE_ID);
         }
 
         // 전체에서 가게 조회
@@ -151,7 +152,7 @@ public class StoreService {
 
         // 유저가 가게를 등록한 유저인지 검증
         if (!userId.equals(store.getUser().getId())) {
-            throw new ForbiddenException("해당 가게에 대한 수정 권한이 없습니다.");
+            throw new CustomException(ErrorCode.NOT_STORE_OWNER_MODIFY);
         }
 
         // 카테고리 조회
@@ -176,19 +177,19 @@ public class StoreService {
 
         // 유저가 사장님 권한을 가졌는지 검증
         if (!user.getRole().equals(UserRole.OWNER)) {
-            throw new ForbiddenException("가게 사장님이 아닙니다.");
+            throw new CustomException(ErrorCode.NOT_OWNER);
         }
 
         Store store = storeRepository.findByIdAndIsDeletedFalseOrElseThrow(storeId);
 
         // 유저가 가게를 등록한 유저인지 검증
         if (!user.getId().equals(store.getUser().getId())) {
-            throw new ForbiddenException("해당 가게에 대한 삭제 권한이 없습니다.");
+            throw new CustomException(ErrorCode.NOT_STORE_OWNER_DELETE);
         }
 
         // 폐업한 가게를 다시 폐업하려고 할 때
         if (store.isDeleted()) {
-            throw new IllegalArgumentException("이미 폐업한 가게 입니다.");
+            throw new CustomException(ErrorCode.ALREADY_STORE_DELETED);
         }
 
         storeRepository.delete(store);

--- a/src/main/java/org/example/baedalteam27/global/exception/ErrorCode.java
+++ b/src/main/java/org/example/baedalteam27/global/exception/ErrorCode.java
@@ -12,17 +12,28 @@ public enum ErrorCode {
     INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "USER_002", "비밀번호 형식이 유효하지 않습니다."),
     EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "USER_003", "이미 존재하는 이메일입니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "USER_004", "비밀번호가 일치하지 않습니다."),
+    CATEGORY_NAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "CATEGORY_001", "이미 존재하는 카테고리 이름입니다."),
+    STORE_LIMIT_EXCEPTION(HttpStatus.BAD_REQUEST, "STORE_001", "가게는 최대 3개까지만 등록할 수 있습니다."),
+    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "REQ_001", "카테고리 또는 가게명 중 하나만 입력! 또는 둘 다 입력X"),
+    NULL_STORE_ID(HttpStatus.BAD_REQUEST, "REQ_002", "가게 번호는 필수!"),
 
     // 401 Unauthorized
     UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "USER_005", "인증되지 않은 사용자입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_001", "유효하지 않은 리프레시 토큰입니다."),
+
+    // 403 Forbidden
+    NOT_ADMIN(HttpStatus.FORBIDDEN, "AUTH_002", "가게를 등록할 권한이 없습니다."),
+    NOT_OWNER(HttpStatus.FORBIDDEN, "AUTH_003", "가게를 등록할 권한이 없습니다."),
+    NOT_STORE_OWNER_MODIFY(HttpStatus.FORBIDDEN, "AUTH_004", "해당 가게에 대한 수정 권한이 없습니다."),
+    NOT_STORE_OWNER_DELETE(HttpStatus.FORBIDDEN, "AUTH_005", "해당 가게에 대한 삭제 권한이 없습니다."),
 
     // 404 Not Found
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_006", "사용자를 찾을 수 없습니다."),
 
     // 409 Conflict
     ALREADY_WITHDRAWN(HttpStatus.CONFLICT, "USER_007", "이미 탈퇴한 사용자입니다."),
-    ALREADY_LOGOUT(HttpStatus.CONFLICT, "USER_008", "이미 로그아웃된 사용자입니다.");
+    ALREADY_LOGOUT(HttpStatus.CONFLICT, "USER_008", "이미 로그아웃된 사용자입니다."),
+    ALREADY_STORE_DELETED(HttpStatus.CONFLICT, "STORE_002", "이미 폐업한 가게입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/org/example/baedalteam27/global/exception/ForbiddenException.java
+++ b/src/main/java/org/example/baedalteam27/global/exception/ForbiddenException.java
@@ -1,7 +1,0 @@
-package org.example.baedalteam27.global.exception;
-
-public class ForbiddenException extends RuntimeException{
-    public ForbiddenException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/org/example/baedalteam27/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/baedalteam27/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,5 @@
 package org.example.baedalteam27.global.exception;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;

--- a/src/test/java/org/example/baedalteam27/domain/category/service/CategoryServiceTest.java
+++ b/src/test/java/org/example/baedalteam27/domain/category/service/CategoryServiceTest.java
@@ -175,6 +175,50 @@ class CategoryServiceTest {
     }
 
     @Test
-    void deleteCategory() {
+    void deleteCategory_성공() {
+        // given
+        Long userId = 1L;
+        User user = new User("email", "password", UserRole.ADMIN, "", "");
+        given(userRepository.getUserByUserId(userId)).willReturn(user);
+
+        Long categoryId = 1L;
+        Category category = new Category("한식");
+        given(categoryRepository.findByIdAndIsDeletedFalseOrElseThrow(categoryId)).willReturn(category);
+
+        // when
+        categoryService.deleteCategory(categoryId, userId);
+
+        // then
+        assertTrue(category.isDeleted());
+    }
+
+    @Test
+    void deleteCategory_실패_USER인_경우() {
+        // given
+        Long userId = 1L;
+        User user = new User("email", "password", UserRole.USER, "", "");
+        given(userRepository.getUserByUserId(userId)).willReturn(user);
+
+        Long categoryId = 1L;
+
+        // when
+        // then
+        CustomException customException = assertThrows(CustomException.class, () -> categoryService.deleteCategory(categoryId, userId));
+        assertEquals(ErrorCode.NOT_ADMIN, customException.getErrorCode());
+    }
+
+    @Test
+    void deleteCategory_실패_OWNER인_경우() {
+        // given
+        Long userId = 1L;
+        User user = new User("email", "password", UserRole.OWNER, "", "");
+        given(userRepository.getUserByUserId(userId)).willReturn(user);
+
+        Long categoryId = 1L;
+
+        // when
+        // then
+        CustomException customException = assertThrows(CustomException.class, () -> categoryService.deleteCategory(categoryId, userId));
+        assertEquals(ErrorCode.NOT_ADMIN, customException.getErrorCode());
     }
 }

--- a/src/test/java/org/example/baedalteam27/domain/category/service/CategoryServiceTest.java
+++ b/src/test/java/org/example/baedalteam27/domain/category/service/CategoryServiceTest.java
@@ -44,7 +44,11 @@ class CategoryServiceTest {
     void saveCategory_성공() {
         // given
         Long userId = 1L;
-        User user = new User("email", "password", UserRole.ADMIN, "", "");
+        User user = User.builder()
+                .email("email")
+                .password("password")
+                .role(UserRole.ADMIN)
+                .build();
         given(userRepository.getUserByUserId(userId)).willReturn(user);
 
         String name = "한식";
@@ -66,7 +70,11 @@ class CategoryServiceTest {
     void saveCategory_USER인_경우() {
         // given
         Long userId = 1L;
-        User user = new User("email", "password", UserRole.USER, "", "");
+        User user = User.builder()
+                .email("email")
+                .password("password")
+                .role(UserRole.USER)
+                .build();
         given(userRepository.getUserByUserId(userId)).willReturn(user);
         CategoryRequestDto dto = new CategoryRequestDto("한식");
 
@@ -80,7 +88,11 @@ class CategoryServiceTest {
     void saveCategory_OWNER인_경우() {
         // given
         Long userId = 1L;
-        User user = new User("email", "password", UserRole.OWNER, "", "");
+        User user = User.builder()
+                .email("email")
+                .password("password")
+                .role(UserRole.OWNER)
+                .build();
         given(userRepository.getUserByUserId(userId)).willReturn(user);
         CategoryRequestDto dto = new CategoryRequestDto("한식");
 
@@ -115,7 +127,11 @@ class CategoryServiceTest {
         UpdateCategoryRequestDto dto = new UpdateCategoryRequestDto("양식");
 
         Long userId = 1L;
-        User user = new User("email", "password", UserRole.ADMIN, "", "");
+        User user = User.builder()
+                .email("email")
+                .password("password")
+                .role(UserRole.ADMIN)
+                .build();
         given(userRepository.getUserByUserId(userId)).willReturn(user);
 
         // when
@@ -132,7 +148,11 @@ class CategoryServiceTest {
         UpdateCategoryRequestDto dto = new UpdateCategoryRequestDto("양식");
 
         Long userId = 1L;
-        User user = new User("email", "password", UserRole.USER, "", "");
+        User user = User.builder()
+                .email("email")
+                .password("password")
+                .role(UserRole.USER)
+                .build();
         given(userRepository.getUserByUserId(userId)).willReturn(user);
 
         // when
@@ -148,7 +168,11 @@ class CategoryServiceTest {
         UpdateCategoryRequestDto dto = new UpdateCategoryRequestDto("양식");
 
         Long userId = 1L;
-        User user = new User("email", "password", UserRole.OWNER, "", "");
+        User user = User.builder()
+                .email("email")
+                .password("password")
+                .role(UserRole.OWNER)
+                .build();
         given(userRepository.getUserByUserId(userId)).willReturn(user);
 
         // when
@@ -166,7 +190,11 @@ class CategoryServiceTest {
         UpdateCategoryRequestDto dto = new UpdateCategoryRequestDto("한식");
 
         Long userId = 1L;
-        User user = new User("email", "password", UserRole.ADMIN, "", "");
+        User user = User.builder()
+                .email("email")
+                .password("password")
+                .role(UserRole.ADMIN)
+                .build();
         given(userRepository.getUserByUserId(userId)).willReturn(user);
 
         // when
@@ -179,7 +207,11 @@ class CategoryServiceTest {
     void deleteCategory_성공() {
         // given
         Long userId = 1L;
-        User user = new User("email", "password", UserRole.ADMIN, "", "");
+        User user = User.builder()
+                .email("email")
+                .password("password")
+                .role(UserRole.ADMIN)
+                .build();
         given(userRepository.getUserByUserId(userId)).willReturn(user);
 
         Long categoryId = 1L;
@@ -198,7 +230,11 @@ class CategoryServiceTest {
     void deleteCategory_실패_USER인_경우() {
         // given
         Long userId = 1L;
-        User user = new User("email", "password", UserRole.USER, "", "");
+        User user = User.builder()
+                .email("email")
+                .password("password")
+                .role(UserRole.USER)
+                .build();
         given(userRepository.getUserByUserId(userId)).willReturn(user);
 
         Long categoryId = 1L;
@@ -213,7 +249,11 @@ class CategoryServiceTest {
     void deleteCategory_실패_OWNER인_경우() {
         // given
         Long userId = 1L;
-        User user = new User("email", "password", UserRole.OWNER, "", "");
+        User user = User.builder()
+                .email("email")
+                .password("password")
+                .role(UserRole.OWNER)
+                .build();
         given(userRepository.getUserByUserId(userId)).willReturn(user);
 
         Long categoryId = 1L;

--- a/src/test/java/org/example/baedalteam27/domain/category/service/CategoryServiceTest.java
+++ b/src/test/java/org/example/baedalteam27/domain/category/service/CategoryServiceTest.java
@@ -7,6 +7,8 @@ import org.example.baedalteam27.domain.category.repository.CategoryRepository;
 import org.example.baedalteam27.domain.user.UserRole;
 import org.example.baedalteam27.domain.user.entitiy.User;
 import org.example.baedalteam27.domain.user.repository.UserRepository;
+import org.example.baedalteam27.global.exception.CustomException;
+import org.example.baedalteam27.global.exception.ErrorCode;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -15,6 +17,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
@@ -54,7 +58,31 @@ class CategoryServiceTest {
     }
 
     @Test
-    void saveCategory_관리자_권한이_아닌_경우() {
+    void saveCategory_USER인_경우() {
+        // given
+        Long userId = 1L;
+        User user = new User("email", "password", UserRole.USER, "", "");
+        given(userRepository.getUserByUserId(userId)).willReturn(user);
+        CategoryRequestDto dto = new CategoryRequestDto("한식");
+
+        // when
+        // then
+        CustomException customException = assertThrows(CustomException.class, () -> categoryService.saveCategory(dto, userId));
+        assertEquals(ErrorCode.NOT_ADMIN, customException.getErrorCode());
+    }
+
+    @Test
+    void saveCategory_OWNER인_경우() {
+        // given
+        Long userId = 1L;
+        User user = new User("email", "password", UserRole.OWNER, "", "");
+        given(userRepository.getUserByUserId(userId)).willReturn(user);
+        CategoryRequestDto dto = new CategoryRequestDto("한식");
+
+        // when
+        // then
+        CustomException customException = assertThrows(CustomException.class, () -> categoryService.saveCategory(dto, userId));
+        assertEquals(ErrorCode.NOT_ADMIN, customException.getErrorCode());
     }
 
     @Test

--- a/src/test/java/org/example/baedalteam27/domain/category/service/CategoryServiceTest.java
+++ b/src/test/java/org/example/baedalteam27/domain/category/service/CategoryServiceTest.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -189,7 +190,8 @@ class CategoryServiceTest {
         categoryService.deleteCategory(categoryId, userId);
 
         // then
-        assertTrue(category.isDeleted());
+        // assertTrue(category.isDeleted() softDelete 라서 검증 방법 어떻게 해야 할지....
+        verify(categoryRepository).delete(category);
     }
 
     @Test

--- a/src/test/java/org/example/baedalteam27/domain/category/service/CategoryServiceTest.java
+++ b/src/test/java/org/example/baedalteam27/domain/category/service/CategoryServiceTest.java
@@ -1,0 +1,71 @@
+package org.example.baedalteam27.domain.category.service;
+
+import org.example.baedalteam27.domain.category.dto.request.CategoryRequestDto;
+import org.example.baedalteam27.domain.category.dto.response.CategoryResponseDto;
+import org.example.baedalteam27.domain.category.entity.Category;
+import org.example.baedalteam27.domain.category.repository.CategoryRepository;
+import org.example.baedalteam27.domain.user.UserRole;
+import org.example.baedalteam27.domain.user.entitiy.User;
+import org.example.baedalteam27.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+
+@ExtendWith(MockitoExtension.class)
+class CategoryServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @InjectMocks
+    private CategoryService categoryService;
+
+    @Test
+    void saveCategory_성공() {
+        // given
+        Long userId = 1L;
+        User user = new User("email", "password", UserRole.ADMIN, "", "");
+        given(userRepository.getUserByUserId(userId)).willReturn(user);
+
+        String name = "한식";
+        Category category = new Category(name);
+        ReflectionTestUtils.setField(category, "id", 1L);
+        CategoryRequestDto dto = new CategoryRequestDto(name);
+        given(categoryRepository.save(any(Category.class))).willReturn(category);
+
+        // when
+        CategoryResponseDto categoryResponseDto = categoryService.saveCategory(dto, userId);
+
+        // then
+        assertThat(categoryResponseDto).isNotNull();
+        assertThat(categoryResponseDto.getName()).isEqualTo(name);
+        assertThat(categoryResponseDto.getId()).isEqualTo(1L);
+    }
+
+    @Test
+    void saveCategory_관리자_권한이_아닌_경우() {
+    }
+
+    @Test
+    void findCategories() {
+    }
+
+    @Test
+    void updateCategory() {
+    }
+
+    @Test
+    void deleteCategory() {
+    }
+}

--- a/src/test/java/org/example/baedalteam27/domain/category/service/CategoryServiceTest.java
+++ b/src/test/java/org/example/baedalteam27/domain/category/service/CategoryServiceTest.java
@@ -120,8 +120,24 @@ class CategoryServiceTest {
         // when
         categoryService.updateCategory(categoryId, dto, userId);
 
-        //then
+        // then
         assertEquals("양식", category.getName());
+    }
+
+    @Test
+    void updateCategory_실패_USER인_경우() {
+        // given
+        Long categoryId = 1L;
+        UpdateCategoryRequestDto dto = new UpdateCategoryRequestDto("양식");
+
+        Long userId = 1L;
+        User user = new User("email", "password", UserRole.USER, "", "");
+        given(userRepository.getUserByUserId(userId)).willReturn(user);
+
+        // when
+        // then
+        CustomException customException = assertThrows(CustomException.class, () -> categoryService.updateCategory(categoryId, dto, userId));
+        assertEquals(ErrorCode.NOT_ADMIN, customException.getErrorCode());
     }
 
     @Test

--- a/src/test/java/org/example/baedalteam27/domain/category/service/CategoryServiceTest.java
+++ b/src/test/java/org/example/baedalteam27/domain/category/service/CategoryServiceTest.java
@@ -157,6 +157,24 @@ class CategoryServiceTest {
     }
 
     @Test
+    void updateCategory_실패_중복된_이름인_경우() {
+        // given
+        Long categoryId = 1L;
+        Category category = new Category("한식");
+        given(categoryRepository.findByIdAndIsDeletedFalseOrElseThrow(categoryId)).willReturn(category);
+        UpdateCategoryRequestDto dto = new UpdateCategoryRequestDto("한식");
+
+        Long userId = 1L;
+        User user = new User("email", "password", UserRole.ADMIN, "", "");
+        given(userRepository.getUserByUserId(userId)).willReturn(user);
+
+        // when
+        // then
+        CustomException customException = assertThrows(CustomException.class, () -> categoryService.updateCategory(categoryId, dto, userId));
+        assertEquals(ErrorCode.CATEGORY_NAME_ALREADY_EXISTS, customException.getErrorCode());
+    }
+
+    @Test
     void deleteCategory() {
     }
 }

--- a/src/test/java/org/example/baedalteam27/domain/category/service/CategoryServiceTest.java
+++ b/src/test/java/org/example/baedalteam27/domain/category/service/CategoryServiceTest.java
@@ -1,6 +1,7 @@
 package org.example.baedalteam27.domain.category.service;
 
 import org.example.baedalteam27.domain.category.dto.request.CategoryRequestDto;
+import org.example.baedalteam27.domain.category.dto.request.UpdateCategoryRequestDto;
 import org.example.baedalteam27.domain.category.dto.response.CategoryResponseDto;
 import org.example.baedalteam27.domain.category.dto.response.FindCategoriesResponseDto;
 import org.example.baedalteam27.domain.category.entity.Category;
@@ -105,7 +106,22 @@ class CategoryServiceTest {
     }
 
     @Test
-    void updateCategory() {
+    void updateCategory_성공() {
+        // given
+        Long categoryId = 1L;
+        Category category = new Category("한식");
+        given(categoryRepository.findByIdAndIsDeletedFalseOrElseThrow(categoryId)).willReturn(category);
+        UpdateCategoryRequestDto dto = new UpdateCategoryRequestDto("양식");
+
+        Long userId = 1L;
+        User user = new User("email", "password", UserRole.ADMIN, "", "");
+        given(userRepository.getUserByUserId(userId)).willReturn(user);
+
+        // when
+        categoryService.updateCategory(categoryId, dto, userId);
+
+        //then
+        assertEquals("양식", category.getName());
     }
 
     @Test

--- a/src/test/java/org/example/baedalteam27/domain/category/service/CategoryServiceTest.java
+++ b/src/test/java/org/example/baedalteam27/domain/category/service/CategoryServiceTest.java
@@ -2,6 +2,7 @@ package org.example.baedalteam27.domain.category.service;
 
 import org.example.baedalteam27.domain.category.dto.request.CategoryRequestDto;
 import org.example.baedalteam27.domain.category.dto.response.CategoryResponseDto;
+import org.example.baedalteam27.domain.category.dto.response.FindCategoriesResponseDto;
 import org.example.baedalteam27.domain.category.entity.Category;
 import org.example.baedalteam27.domain.category.repository.CategoryRepository;
 import org.example.baedalteam27.domain.user.UserRole;
@@ -16,9 +17,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.Arrays;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
@@ -86,7 +89,19 @@ class CategoryServiceTest {
     }
 
     @Test
-    void findCategories() {
+    void findCategories_성공() {
+        // given
+        Category category = new Category("한식");
+        Category category2 = new Category("일식");
+        List<Category> categories = Arrays.asList(category, category2);
+        given(categoryRepository.findAll()).willReturn(categories);
+
+        // when
+        List<FindCategoriesResponseDto> findCategoriesResponseDtos = categoryService.findCategories();
+
+        // then
+        assertEquals("한식", findCategoriesResponseDtos.get(0).getName());
+        assertEquals("일식", findCategoriesResponseDtos.get(1).getName());
     }
 
     @Test

--- a/src/test/java/org/example/baedalteam27/domain/category/service/CategoryServiceTest.java
+++ b/src/test/java/org/example/baedalteam27/domain/category/service/CategoryServiceTest.java
@@ -141,6 +141,22 @@ class CategoryServiceTest {
     }
 
     @Test
+    void updateCategory_실패_OWNER인_경우() {
+        // given
+        Long categoryId = 1L;
+        UpdateCategoryRequestDto dto = new UpdateCategoryRequestDto("양식");
+
+        Long userId = 1L;
+        User user = new User("email", "password", UserRole.OWNER, "", "");
+        given(userRepository.getUserByUserId(userId)).willReturn(user);
+
+        // when
+        // then
+        CustomException customException = assertThrows(CustomException.class, () -> categoryService.updateCategory(categoryId, dto, userId));
+        assertEquals(ErrorCode.NOT_ADMIN, customException.getErrorCode());
+    }
+
+    @Test
     void deleteCategory() {
     }
 }

--- a/src/test/java/org/example/baedalteam27/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/org/example/baedalteam27/domain/store/service/StoreServiceTest.java
@@ -377,7 +377,13 @@ class StoreServiceTest {
         ReflectionTestUtils.setField(store, "id", storeId);
         given(storeRepository.findByIdAndIsDeletedFalseOrElseThrow(storeId)).willReturn(store);
 
-        Menu menu = new Menu(store, "김밥", 5000, "김, 햄, 시금치 등등", false);
+        Menu menu = Menu.builder()
+                .store(store)
+                .name("김밥")
+                .price(5000)
+                .description("김, 햄, 시금치 등등")
+                .isSoldOut(false)
+                .build();
         ReflectionTestUtils.setField(menu, "id", 1L);
         List<Menu> menus = Arrays.asList(menu);
         ReflectionTestUtils.setField(store, "menus", menus);

--- a/src/test/java/org/example/baedalteam27/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/org/example/baedalteam27/domain/store/service/StoreServiceTest.java
@@ -399,4 +399,20 @@ class StoreServiceTest {
         CustomException customException = assertThrows(CustomException.class, () -> storeService.deleteStore(userId, storeId));
         assertEquals(ErrorCode.NOT_OWNER, customException.getErrorCode());
     }
+
+    @Test
+    void deleteStore_실패_ADMIN인경우() {
+        // given
+        Long userId = 1L;
+        User user = new User("email", "password", UserRole.ADMIN, "", "");
+        ReflectionTestUtils.setField(user, "id", userId);
+        given(userRepository.getUserByUserId(userId)).willReturn(user);
+
+        Long storeId = 1L;
+
+        // when
+        // then
+        CustomException customException = assertThrows(CustomException.class, () -> storeService.deleteStore(userId, storeId));
+        assertEquals(ErrorCode.NOT_OWNER, customException.getErrorCode());
+    }
 }

--- a/src/test/java/org/example/baedalteam27/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/org/example/baedalteam27/domain/store/service/StoreServiceTest.java
@@ -56,7 +56,11 @@ class StoreServiceTest {
     void saveStore_성공() {
         // given
         Long userId = 1L;
-        User user = new User("email", "password", UserRole.OWNER, "", "");
+        User user = User.builder()
+                .email("email")
+                .password("password")
+                .role(UserRole.OWNER)
+                .build();
         given(userRepository.getUserByUserId(userId)).willReturn(user);
 
         Long categoryId = 1L;
@@ -87,7 +91,11 @@ class StoreServiceTest {
     void saveStore_실패_USER인_경우() {
         // given
         Long userId = 1L;
-        User user = new User("email", "password", UserRole.USER, "", "");
+        User user = User.builder()
+                .email("email")
+                .password("password")
+                .role(UserRole.USER)
+                .build();
         given(userRepository.getUserByUserId(userId)).willReturn(user);
 
         Long categoryId = 1L;
@@ -108,7 +116,11 @@ class StoreServiceTest {
     void saveStore_실패_ADMIN인_경우() {
         // given
         Long userId = 1L;
-        User user = new User("email", "password", UserRole.ADMIN, "", "");
+        User user = User.builder()
+                .email("email")
+                .password("password")
+                .role(UserRole.ADMIN)
+                .build();
         given(userRepository.getUserByUserId(userId)).willReturn(user);
 
         Long categoryId = 1L;
@@ -129,7 +141,11 @@ class StoreServiceTest {
     void saveStore_실패_소유한_가게의_갯수가_4개이상인_경우() {
         // given
         Long userId = 1L;
-        User user = new User("email", "password", UserRole.OWNER, "", "");
+        User user = User.builder()
+                .email("email")
+                .password("password")
+                .role(UserRole.OWNER)
+                .build();
         given(userRepository.getUserByUserId(userId)).willReturn(user);
 
         Long categoryId = 1L;
@@ -151,7 +167,11 @@ class StoreServiceTest {
     void findStores_성공_카테고리Id로_조회() {
         // given
         Long userId = 1L;
-        User user = new User("email", "password", UserRole.OWNER, "", "");
+        User user = User.builder()
+                .email("email")
+                .password("password")
+                .role(UserRole.OWNER)
+                .build();
         ReflectionTestUtils.setField(user, "id", userId);
 
         Long categoryId = 1L;
@@ -184,7 +204,11 @@ class StoreServiceTest {
     void findStores_성공_가게이름으로_조회() {
         // given
         Long userId = 1L;
-        User user = new User("email", "password", UserRole.OWNER, "", "");
+        User user = User.builder()
+                .email("email")
+                .password("password")
+                .role(UserRole.OWNER)
+                .build();
         ReflectionTestUtils.setField(user, "id", userId);
 
         Long categoryId = 1L;
@@ -217,7 +241,11 @@ class StoreServiceTest {
     void findStores_성공_Param이_null인경우() {
         // given
         Long userId = 1L;
-        User user = new User("email", "password", UserRole.OWNER, "", "");
+        User user = User.builder()
+                .email("email")
+                .password("password")
+                .role(UserRole.OWNER)
+                .build();
         ReflectionTestUtils.setField(user, "id", userId);
 
         Long categoryId = 1L;
@@ -264,7 +292,11 @@ class StoreServiceTest {
         // given
         Category category = new Category("한식");
 
-        User user = new User("email", "password", UserRole.USER, "", "");
+        User user = User.builder()
+                .email("email")
+                .password("password")
+                .role(UserRole.USER)
+                .build();
 
         Long storeId = 1L;
         LocalTime openTime = LocalTime.parse("16:00:00");
@@ -313,7 +345,11 @@ class StoreServiceTest {
     void updateStore_성공() {
         // given
         Long userId = 1L;
-        User user = new User("email", "password", UserRole.OWNER, "", "");
+        User user = User.builder()
+                .email("email")
+                .password("password")
+                .role(UserRole.OWNER)
+                .build();
         ReflectionTestUtils.setField(user, "id", userId);
 
         Long categoryId = 1L;
@@ -344,7 +380,11 @@ class StoreServiceTest {
     void updateStore_실패_가게를_등록한_사장이_아닌경우() {
         // given
         Long userId = 2L;
-        User user = new User("email", "password", UserRole.OWNER, "", "");
+        User user = User.builder()
+                .email("email")
+                .password("password")
+                .role(UserRole.OWNER)
+                .build();
         ReflectionTestUtils.setField(user, "id", 1L);
 
         Long categoryId = 1L;
@@ -367,7 +407,11 @@ class StoreServiceTest {
     void deleteStore_성공() {
         // given
         Long userId = 1L;
-        User user = new User("email", "password", UserRole.OWNER, "", "");
+        User user = User.builder()
+                .email("email")
+                .password("password")
+                .role(UserRole.OWNER)
+                .build();
         ReflectionTestUtils.setField(user, "id", userId);
         given(userRepository.getUserByUserId(userId)).willReturn(user);
 
@@ -391,7 +435,11 @@ class StoreServiceTest {
     void deleteStore_실패_USER인경우() {
         // given
         Long userId = 1L;
-        User user = new User("email", "password", UserRole.USER, "", "");
+        User user = User.builder()
+                .email("email")
+                .password("password")
+                .role(UserRole.USER)
+                .build();
         ReflectionTestUtils.setField(user, "id", userId);
         given(userRepository.getUserByUserId(userId)).willReturn(user);
 
@@ -407,7 +455,11 @@ class StoreServiceTest {
     void deleteStore_실패_ADMIN인경우() {
         // given
         Long userId = 1L;
-        User user = new User("email", "password", UserRole.ADMIN, "", "");
+        User user = User.builder()
+                .email("email")
+                .password("password")
+                .role(UserRole.ADMIN)
+                .build();
         ReflectionTestUtils.setField(user, "id", userId);
         given(userRepository.getUserByUserId(userId)).willReturn(user);
 
@@ -423,8 +475,16 @@ class StoreServiceTest {
     void deleteStore_실패_가게를_등록한_사장이_아닌경우() {
         // given
         Long userId = 1L;
-        User user1 = new User("email", "password", UserRole.OWNER, "", "");
-        User user2 = new User("email", "password", UserRole.OWNER, "", "");
+        User user1 = User.builder()
+                .email("email")
+                .password("password")
+                .role(UserRole.OWNER)
+                .build();
+        User user2 = User.builder()
+                .email("email")
+                .password("password")
+                .role(UserRole.OWNER)
+                .build();
         ReflectionTestUtils.setField(user1, "id", userId);
         ReflectionTestUtils.setField(user2, "id", 2L);
         given(userRepository.getUserByUserId(userId)).willReturn(user1);
@@ -447,7 +507,11 @@ class StoreServiceTest {
     void deleteStore_실패_폐업한_가게를_다시_폐업하려는_경우() {
         // given
         Long userId = 1L;
-        User user = new User("email", "password", UserRole.OWNER, "", "");
+        User user = User.builder()
+                .email("email")
+                .password("password")
+                .role(UserRole.OWNER)
+                .build();
         ReflectionTestUtils.setField(user, "id", userId);
         given(userRepository.getUserByUserId(userId)).willReturn(user);
 

--- a/src/test/java/org/example/baedalteam27/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/org/example/baedalteam27/domain/store/service/StoreServiceTest.java
@@ -4,6 +4,7 @@ import org.example.baedalteam27.domain.category.entity.Category;
 import org.example.baedalteam27.domain.category.repository.CategoryRepository;
 import org.example.baedalteam27.domain.menu.entity.Menu;
 import org.example.baedalteam27.domain.store.dto.request.SaveStoreRequestDto;
+import org.example.baedalteam27.domain.store.dto.request.UpdateStoreRequestDto;
 import org.example.baedalteam27.domain.store.dto.response.SaveStoreResponseDto;
 import org.example.baedalteam27.domain.store.dto.response.StoreNameResponseDto;
 import org.example.baedalteam27.domain.store.dto.response.StoreResponseDto;
@@ -305,7 +306,34 @@ class StoreServiceTest {
     }
 
     @Test
-    void updateStore() {
+    void updateStore_성공() {
+        // given
+        Long userId = 1L;
+        User user = new User("email", "password", UserRole.OWNER, "", "");
+        ReflectionTestUtils.setField(user, "id", userId);
+
+        Long categoryId = 1L;
+        Category category = new Category("한식");
+        given(categoryRepository.findByIdAndIsDeletedFalseOrElseThrow(categoryId)).willReturn(category);
+
+        Long storeId = 1L;
+        LocalTime openTime = LocalTime.parse("16:00:00");
+        LocalTime closedTime = LocalTime.parse("22:00:00");
+        Store store = new Store("김밥집", "한국", "010", openTime, closedTime, 7000L, user, category);
+        given(storeRepository.findByIdAndIsDeletedFalseOrElseThrow(storeId)).willReturn(store);
+        UpdateStoreRequestDto updateStoreRequestDto = new UpdateStoreRequestDto("김밥집1", "한국1", "0101", openTime, closedTime, 70000L, categoryId);
+
+        // when
+        storeService.updateStore(userId, updateStoreRequestDto, storeId);
+
+        // then
+        assertEquals("김밥집1", store.getStoreName());
+        assertEquals("한국1", store.getAddress());
+        assertEquals("0101", store.getPhoneNumber());
+        assertEquals(openTime, store.getOpenTime());
+        assertEquals(closedTime, store.getClosedTime());
+        assertEquals(70000L, store.getMinOrderPrice());
+        assertEquals(category, store.getCategory());
     }
 
     @Test

--- a/src/test/java/org/example/baedalteam27/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/org/example/baedalteam27/domain/store/service/StoreServiceTest.java
@@ -294,6 +294,17 @@ class StoreServiceTest {
     }
 
     @Test
+    void findStore_실패_storeId가_null인경우() {
+        // given
+        Long storeId = null;
+
+        // when
+        // then
+        CustomException customException = assertThrows(CustomException.class, () -> storeService.findStore(storeId));
+        assertEquals(ErrorCode.NULL_STORE_ID, customException.getErrorCode());
+    }
+
+    @Test
     void updateStore() {
     }
 

--- a/src/test/java/org/example/baedalteam27/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/org/example/baedalteam27/domain/store/service/StoreServiceTest.java
@@ -1,0 +1,86 @@
+package org.example.baedalteam27.domain.store.service;
+
+import org.example.baedalteam27.domain.category.entity.Category;
+import org.example.baedalteam27.domain.category.repository.CategoryRepository;
+import org.example.baedalteam27.domain.store.dto.request.SaveStoreRequestDto;
+import org.example.baedalteam27.domain.store.dto.response.SaveStoreResponseDto;
+import org.example.baedalteam27.domain.store.entity.Store;
+import org.example.baedalteam27.domain.store.repository.StoreRepository;
+import org.example.baedalteam27.domain.user.UserRole;
+import org.example.baedalteam27.domain.user.entitiy.User;
+import org.example.baedalteam27.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalTime;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.ArgumentMatchers.any;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@ExtendWith(MockitoExtension.class)
+class StoreServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @InjectMocks
+    private StoreService storeService;
+
+    @Test
+    void saveStore_성공() {
+        // given
+        Long userId = 1L;
+        User user = new User("email", "password", UserRole.OWNER, "", "");
+        given(userRepository.getUserByUserId(userId)).willReturn(user);
+
+        Long categoryId = 1L;
+        Category category = new Category("한식");
+        given(categoryRepository.findByIdAndIsDeletedFalseOrElseThrow(categoryId)).willReturn(category);
+
+        LocalTime openTime = LocalTime.parse("16:00:00");
+        LocalTime closedTime = LocalTime.parse("22:00:00");
+        Store store = new Store("김밥집", "한국", "010", openTime, closedTime, 7000L, user, category);
+        SaveStoreRequestDto dto = new SaveStoreRequestDto("김밥집", "한국", "010", openTime, closedTime, 7000L, categoryId);
+        given(storeRepository.save(any(Store.class))).willReturn(store);
+
+        // when
+        SaveStoreResponseDto saveStoreResponseDto = storeService.saveStore(userId, dto);
+
+        // then
+        assertThat(saveStoreResponseDto).isNotNull();
+        assertThat(saveStoreResponseDto.getStoreName()).isEqualTo("김밥집");
+        assertThat(saveStoreResponseDto.getAddress()).isEqualTo("한국");
+        assertThat(saveStoreResponseDto.getPhoneNumber()).isEqualTo("010");
+        assertThat(saveStoreResponseDto.getOpenTime()).isEqualTo(openTime);
+        assertThat(saveStoreResponseDto.getClosedTime()).isEqualTo(closedTime);
+        assertThat(saveStoreResponseDto.getMinOrderPrice()).isEqualTo(7000L);
+        assertThat(saveStoreResponseDto.getCategoryName()).isEqualTo(category.getName());
+    }
+
+    @Test
+    void findStores() {
+    }
+
+    @Test
+    void findStore() {
+    }
+
+    @Test
+    void updateStore() {
+    }
+
+    @Test
+    void deleteStore() {
+    }
+}

--- a/src/test/java/org/example/baedalteam27/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/org/example/baedalteam27/domain/store/service/StoreServiceTest.java
@@ -94,6 +94,27 @@ class StoreServiceTest {
     }
 
     @Test
+    void saveStore_실패_ADMIN인_경우() {
+        // given
+        Long userId = 1L;
+        User user = new User("email", "password", UserRole.ADMIN, "", "");
+        given(userRepository.getUserByUserId(userId)).willReturn(user);
+
+        Long categoryId = 1L;
+        Category category = new Category("한식");
+        given(categoryRepository.findByIdAndIsDeletedFalseOrElseThrow(categoryId)).willReturn(category);
+
+        LocalTime openTime = LocalTime.parse("16:00:00");
+        LocalTime closedTime = LocalTime.parse("22:00:00");
+        SaveStoreRequestDto dto = new SaveStoreRequestDto("김밥집", "한국", "010", openTime, closedTime, 7000L, categoryId);
+
+        // when
+        // then
+        CustomException customException = assertThrows(CustomException.class, () -> storeService.saveStore(userId, dto));
+        assertEquals(ErrorCode.NOT_OWNER, customException.getErrorCode());
+    }
+
+    @Test
     void findStores() {
     }
 

--- a/src/test/java/org/example/baedalteam27/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/org/example/baedalteam27/domain/store/service/StoreServiceTest.java
@@ -69,7 +69,16 @@ class StoreServiceTest {
 
         LocalTime openTime = LocalTime.parse("16:00:00");
         LocalTime closedTime = LocalTime.parse("22:00:00");
-        Store store = new Store("김밥집", "한국", "010", openTime, closedTime, 7000L, user, category);
+        Store store = Store.builder()
+                .storeName("김밥집")
+                .address("한국")
+                .phoneNumber("010")
+                .openTime(openTime)
+                .closedTime(closedTime)
+                .minOrderPrice(7000L)
+                .user(user)
+                .category(category)
+                .build();
         SaveStoreRequestDto dto = new SaveStoreRequestDto("김밥집", "한국", "010", openTime, closedTime, 7000L, categoryId);
         given(storeRepository.save(any(Store.class))).willReturn(store);
 
@@ -180,9 +189,27 @@ class StoreServiceTest {
 
         LocalTime openTime = LocalTime.parse("16:00:00");
         LocalTime closedTime = LocalTime.parse("22:00:00");
-        Store store1 = new Store("김밥집1", "한국", "010", openTime, closedTime, 7000L, user, category);
+        Store store1 = Store.builder()
+                .storeName("김밥집1")
+                .address("한국")
+                .phoneNumber("010")
+                .openTime(openTime)
+                .closedTime(closedTime)
+                .minOrderPrice(7000L)
+                .user(user)
+                .category(category)
+                .build();
         ReflectionTestUtils.setField(store1, "id", 1L);
-        Store store2 = new Store("김밥집2", "한국", "010", openTime, closedTime, 7000L, user, category);
+        Store store2 = Store.builder()
+                .storeName("김밥집2")
+                .address("한국")
+                .phoneNumber("010")
+                .openTime(openTime)
+                .closedTime(closedTime)
+                .minOrderPrice(7000L)
+                .user(user)
+                .category(category)
+                .build();
         ReflectionTestUtils.setField(store2, "id", 2L);
 
         List<Store> storeList = Arrays.asList(store1, store2);
@@ -217,9 +244,27 @@ class StoreServiceTest {
 
         LocalTime openTime = LocalTime.parse("16:00:00");
         LocalTime closedTime = LocalTime.parse("22:00:00");
-        Store store1 = new Store("김밥집1", "한국", "010", openTime, closedTime, 7000L, user, category);
+        Store store1 = Store.builder()
+                .storeName("김밥집1")
+                .address("한국")
+                .phoneNumber("010")
+                .openTime(openTime)
+                .closedTime(closedTime)
+                .minOrderPrice(7000L)
+                .user(user)
+                .category(category)
+                .build();
         ReflectionTestUtils.setField(store1, "id", 1L);
-        Store store2 = new Store("김밥집2", "한국", "010", openTime, closedTime, 7000L, user, category);
+        Store store2 = Store.builder()
+                .storeName("김밥집2")
+                .address("한국")
+                .phoneNumber("010")
+                .openTime(openTime)
+                .closedTime(closedTime)
+                .minOrderPrice(7000L)
+                .user(user)
+                .category(category)
+                .build();
         ReflectionTestUtils.setField(store2, "id", 2L);
 
         List<Store> storeList = Arrays.asList(store1, store2);
@@ -254,9 +299,27 @@ class StoreServiceTest {
 
         LocalTime openTime = LocalTime.parse("16:00:00");
         LocalTime closedTime = LocalTime.parse("22:00:00");
-        Store store1 = new Store("김밥집1", "한국", "010", openTime, closedTime, 7000L, user, category);
+        Store store1 = Store.builder()
+                .storeName("김밥집1")
+                .address("한국")
+                .phoneNumber("010")
+                .openTime(openTime)
+                .closedTime(closedTime)
+                .minOrderPrice(7000L)
+                .user(user)
+                .category(category)
+                .build();
         ReflectionTestUtils.setField(store1, "id", 1L);
-        Store store2 = new Store("김밥집2", "한국", "010", openTime, closedTime, 7000L, user, category);
+        Store store2 = Store.builder()
+                .storeName("김밥집2")
+                .address("한국")
+                .phoneNumber("010")
+                .openTime(openTime)
+                .closedTime(closedTime)
+                .minOrderPrice(7000L)
+                .user(user)
+                .category(category)
+                .build();
         ReflectionTestUtils.setField(store2, "id", 2L);
 
         List<Store> storeList = Arrays.asList(store1, store2);
@@ -301,7 +364,16 @@ class StoreServiceTest {
         Long storeId = 1L;
         LocalTime openTime = LocalTime.parse("16:00:00");
         LocalTime closedTime = LocalTime.parse("22:00:00");
-        Store store = new Store("김밥집", "한국", "010", openTime, closedTime, 7000L, user, category);
+        Store store = Store.builder()
+                .storeName("김밥집")
+                .address("한국")
+                .phoneNumber("010")
+                .openTime(openTime)
+                .closedTime(closedTime)
+                .minOrderPrice(7000L)
+                .user(user)
+                .category(category)
+                .build();
         ReflectionTestUtils.setField(store, "id", storeId);
         given(storeRepository.findByIdAndIsDeletedFalseOrElseThrow(storeId)).willReturn(store);
 
@@ -359,7 +431,16 @@ class StoreServiceTest {
         Long storeId = 1L;
         LocalTime openTime = LocalTime.parse("16:00:00");
         LocalTime closedTime = LocalTime.parse("22:00:00");
-        Store store = new Store("김밥집", "한국", "010", openTime, closedTime, 7000L, user, category);
+        Store store = Store.builder()
+                .storeName("김밥집")
+                .address("한국")
+                .phoneNumber("010")
+                .openTime(openTime)
+                .closedTime(closedTime)
+                .minOrderPrice(7000L)
+                .user(user)
+                .category(category)
+                .build();
         given(storeRepository.findByIdAndIsDeletedFalseOrElseThrow(storeId)).willReturn(store);
         UpdateStoreRequestDto updateStoreRequestDto = new UpdateStoreRequestDto("김밥집1", "한국1", "0101", openTime, closedTime, 70000L, categoryId);
 
@@ -393,7 +474,16 @@ class StoreServiceTest {
         Long storeId = 1L;
         LocalTime openTime = LocalTime.parse("16:00:00");
         LocalTime closedTime = LocalTime.parse("22:00:00");
-        Store store = new Store("김밥집", "한국", "010", openTime, closedTime, 7000L, user, category);
+        Store store = Store.builder()
+                .storeName("김밥집")
+                .address("한국")
+                .phoneNumber("010")
+                .openTime(openTime)
+                .closedTime(closedTime)
+                .minOrderPrice(7000L)
+                .user(user)
+                .category(category)
+                .build();
         given(storeRepository.findByIdAndIsDeletedFalseOrElseThrow(storeId)).willReturn(store);
         UpdateStoreRequestDto updateStoreRequestDto = new UpdateStoreRequestDto("김밥집1", "한국1", "0101", openTime, closedTime, 70000L, categoryId);
 
@@ -421,7 +511,16 @@ class StoreServiceTest {
         Long storeId = 1L;
         LocalTime openTime = LocalTime.parse("16:00:00");
         LocalTime closedTime = LocalTime.parse("22:00:00");
-        Store store = new Store("김밥집", "한국", "010", openTime, closedTime, 7000L, user, category);
+        Store store = Store.builder()
+                .storeName("김밥집")
+                .address("한국")
+                .phoneNumber("010")
+                .openTime(openTime)
+                .closedTime(closedTime)
+                .minOrderPrice(7000L)
+                .user(user)
+                .category(category)
+                .build();
         given(storeRepository.findByIdAndIsDeletedFalseOrElseThrow(storeId)).willReturn(store);
 
         // when
@@ -494,7 +593,16 @@ class StoreServiceTest {
         Long storeId = 1L;
         LocalTime openTime = LocalTime.parse("16:00:00");
         LocalTime closedTime = LocalTime.parse("22:00:00");
-        Store store = new Store("김밥집", "한국", "010", openTime, closedTime, 7000L, user2, category);
+        Store store = Store.builder()
+                .storeName("김밥집")
+                .address("한국")
+                .phoneNumber("010")
+                .openTime(openTime)
+                .closedTime(closedTime)
+                .minOrderPrice(7000L)
+                .user(user2)
+                .category(category)
+                .build();
         given(storeRepository.findByIdAndIsDeletedFalseOrElseThrow(storeId)).willReturn(store);
 
         // when
@@ -520,7 +628,16 @@ class StoreServiceTest {
         Long storeId = 1L;
         LocalTime openTime = LocalTime.parse("16:00:00");
         LocalTime closedTime = LocalTime.parse("22:00:00");
-        Store store = new Store("김밥집", "한국", "010", openTime, closedTime, 7000L, user, category);
+        Store store = Store.builder()
+                .storeName("김밥집")
+                .address("한국")
+                .phoneNumber("010")
+                .openTime(openTime)
+                .closedTime(closedTime)
+                .minOrderPrice(7000L)
+                .user(user)
+                .category(category)
+                .build();
         ReflectionTestUtils.setField(store, "isDeleted", true);
         given(storeRepository.findByIdAndIsDeletedFalseOrElseThrow(storeId)).willReturn(store);
 

--- a/src/test/java/org/example/baedalteam27/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/org/example/baedalteam27/domain/store/service/StoreServiceTest.java
@@ -415,4 +415,28 @@ class StoreServiceTest {
         CustomException customException = assertThrows(CustomException.class, () -> storeService.deleteStore(userId, storeId));
         assertEquals(ErrorCode.NOT_OWNER, customException.getErrorCode());
     }
+
+    @Test
+    void deleteStore_실패_가게를_등록한_사장이_아닌경우() {
+        // given
+        Long userId = 1L;
+        User user1 = new User("email", "password", UserRole.OWNER, "", "");
+        User user2 = new User("email", "password", UserRole.OWNER, "", "");
+        ReflectionTestUtils.setField(user1, "id", userId);
+        ReflectionTestUtils.setField(user2, "id", 2L);
+        given(userRepository.getUserByUserId(userId)).willReturn(user1);
+
+        Category category = new Category("한식");
+
+        Long storeId = 1L;
+        LocalTime openTime = LocalTime.parse("16:00:00");
+        LocalTime closedTime = LocalTime.parse("22:00:00");
+        Store store = new Store("김밥집", "한국", "010", openTime, closedTime, 7000L, user2, category);
+        given(storeRepository.findByIdAndIsDeletedFalseOrElseThrow(storeId)).willReturn(store);
+
+        // when
+        // then
+        CustomException customException = assertThrows(CustomException.class, () -> storeService.deleteStore(userId, storeId));
+        assertEquals(ErrorCode.NOT_STORE_OWNER_DELETE, customException.getErrorCode());
+    }
 }

--- a/src/test/java/org/example/baedalteam27/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/org/example/baedalteam27/domain/store/service/StoreServiceTest.java
@@ -9,6 +9,8 @@ import org.example.baedalteam27.domain.store.repository.StoreRepository;
 import org.example.baedalteam27.domain.user.UserRole;
 import org.example.baedalteam27.domain.user.entitiy.User;
 import org.example.baedalteam27.domain.user.repository.UserRepository;
+import org.example.baedalteam27.global.exception.CustomException;
+import org.example.baedalteam27.global.exception.ErrorCode;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -17,6 +19,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalTime;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.ArgumentMatchers.any;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -66,6 +70,27 @@ class StoreServiceTest {
         assertThat(saveStoreResponseDto.getClosedTime()).isEqualTo(closedTime);
         assertThat(saveStoreResponseDto.getMinOrderPrice()).isEqualTo(7000L);
         assertThat(saveStoreResponseDto.getCategoryName()).isEqualTo(category.getName());
+    }
+
+    @Test
+    void saveStore_실패_USER인_경우() {
+        // given
+        Long userId = 1L;
+        User user = new User("email", "password", UserRole.USER, "", "");
+        given(userRepository.getUserByUserId(userId)).willReturn(user);
+
+        Long categoryId = 1L;
+        Category category = new Category("한식");
+        given(categoryRepository.findByIdAndIsDeletedFalseOrElseThrow(categoryId)).willReturn(category);
+
+        LocalTime openTime = LocalTime.parse("16:00:00");
+        LocalTime closedTime = LocalTime.parse("22:00:00");
+        SaveStoreRequestDto dto = new SaveStoreRequestDto("김밥집", "한국", "010", openTime, closedTime, 7000L, categoryId);
+
+        // when
+        // then
+        CustomException customException = assertThrows(CustomException.class, () -> storeService.saveStore(userId, dto));
+        assertEquals(ErrorCode.NOT_OWNER, customException.getErrorCode());
     }
 
     @Test

--- a/src/test/java/org/example/baedalteam27/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/org/example/baedalteam27/domain/store/service/StoreServiceTest.java
@@ -383,4 +383,20 @@ class StoreServiceTest {
         // then
         verify(storeRepository).delete(store);
     }
+
+    @Test
+    void deleteStore_실패_USER인경우() {
+        // given
+        Long userId = 1L;
+        User user = new User("email", "password", UserRole.USER, "", "");
+        ReflectionTestUtils.setField(user, "id", userId);
+        given(userRepository.getUserByUserId(userId)).willReturn(user);
+
+        Long storeId = 1L;
+
+        // when
+        // then
+        CustomException customException = assertThrows(CustomException.class, () -> storeService.deleteStore(userId, storeId));
+        assertEquals(ErrorCode.NOT_OWNER, customException.getErrorCode());
+    }
 }

--- a/src/test/java/org/example/baedalteam27/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/org/example/baedalteam27/domain/store/service/StoreServiceTest.java
@@ -152,10 +152,11 @@ class StoreServiceTest {
         // given
         Long userId = 1L;
         User user = new User("email", "password", UserRole.OWNER, "", "");
-        given(userRepository.getUserByUserId(userId)).willReturn(user);
+        ReflectionTestUtils.setField(user, "id", userId);
 
         Long categoryId = 1L;
         Category category = new Category("한식");
+        ReflectionTestUtils.setField(category, "id", categoryId);
 
         LocalTime openTime = LocalTime.parse("16:00:00");
         LocalTime closedTime = LocalTime.parse("22:00:00");
@@ -184,10 +185,11 @@ class StoreServiceTest {
         // given
         Long userId = 1L;
         User user = new User("email", "password", UserRole.OWNER, "", "");
-        given(userRepository.getUserByUserId(userId)).willReturn(user);
+        ReflectionTestUtils.setField(user, "id", userId);
 
         Long categoryId = 1L;
         Category category = new Category("한식");
+        ReflectionTestUtils.setField(category, "id", categoryId);
 
         LocalTime openTime = LocalTime.parse("16:00:00");
         LocalTime closedTime = LocalTime.parse("22:00:00");
@@ -216,10 +218,11 @@ class StoreServiceTest {
         // given
         Long userId = 1L;
         User user = new User("email", "password", UserRole.OWNER, "", "");
-        given(userRepository.getUserByUserId(userId)).willReturn(user);
+        ReflectionTestUtils.setField(user, "id", userId);
 
         Long categoryId = 1L;
         Category category = new Category("한식");
+        ReflectionTestUtils.setField(category, "id", categoryId);
 
         LocalTime openTime = LocalTime.parse("16:00:00");
         LocalTime closedTime = LocalTime.parse("22:00:00");

--- a/src/test/java/org/example/baedalteam27/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/org/example/baedalteam27/domain/store/service/StoreServiceTest.java
@@ -239,6 +239,19 @@ class StoreServiceTest {
     }
 
     @Test
+    void findStores_살패_Param이_둘다입력받은경우() {
+        // given
+        Long categoryId = 1L;
+        String storeName = "김밥집";
+        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "storeName"));
+
+        // when
+        // then
+        CustomException customException = assertThrows(CustomException.class, () -> storeService.findStores(categoryId, storeName, pageable));
+        assertEquals(ErrorCode.INVALID_PARAMETER, customException.getErrorCode());
+    }
+
+    @Test
     void findStore() {
     }
 

--- a/src/test/java/org/example/baedalteam27/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/org/example/baedalteam27/domain/store/service/StoreServiceTest.java
@@ -115,6 +115,28 @@ class StoreServiceTest {
     }
 
     @Test
+    void saveStore_실패_소유한_가게의_갯수가_4개이상인_경우() {
+        // given
+        Long userId = 1L;
+        User user = new User("email", "password", UserRole.OWNER, "", "");
+        given(userRepository.getUserByUserId(userId)).willReturn(user);
+
+        Long categoryId = 1L;
+        Category category = new Category("한식");
+        given(categoryRepository.findByIdAndIsDeletedFalseOrElseThrow(categoryId)).willReturn(category);
+
+        LocalTime openTime = LocalTime.parse("16:00:00");
+        LocalTime closedTime = LocalTime.parse("22:00:00");
+        SaveStoreRequestDto dto = new SaveStoreRequestDto("김밥집", "한국", "010", openTime, closedTime, 7000L, categoryId);
+        given(storeRepository.countByUserIdAndIsDeletedFalse(userId)).willReturn(4);
+
+        // when
+        // then
+        CustomException customException = assertThrows(CustomException.class, () -> storeService.saveStore(userId, dto));
+        assertEquals(ErrorCode.STORE_LIMIT_EXCEPTION, customException.getErrorCode());
+    }
+
+    @Test
     void findStores() {
     }
 

--- a/src/test/java/org/example/baedalteam27/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/org/example/baedalteam27/domain/store/service/StoreServiceTest.java
@@ -34,6 +34,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.ArgumentMatchers.any;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -360,6 +361,26 @@ class StoreServiceTest {
     }
 
     @Test
-    void deleteStore() {
+    void deleteStore_성공() {
+        // given
+        Long userId = 1L;
+        User user = new User("email", "password", UserRole.OWNER, "", "");
+        ReflectionTestUtils.setField(user, "id", userId);
+        given(userRepository.getUserByUserId(userId)).willReturn(user);
+
+        Long categoryId = 1L;
+        Category category = new Category("한식");
+
+        Long storeId = 1L;
+        LocalTime openTime = LocalTime.parse("16:00:00");
+        LocalTime closedTime = LocalTime.parse("22:00:00");
+        Store store = new Store("김밥집", "한국", "010", openTime, closedTime, 7000L, user, category);
+        given(storeRepository.findByIdAndIsDeletedFalseOrElseThrow(storeId)).willReturn(store);
+
+        // when
+        storeService.deleteStore(userId, storeId);
+
+        // then
+        verify(storeRepository).delete(store);
     }
 }

--- a/src/test/java/org/example/baedalteam27/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/org/example/baedalteam27/domain/store/service/StoreServiceTest.java
@@ -439,4 +439,27 @@ class StoreServiceTest {
         CustomException customException = assertThrows(CustomException.class, () -> storeService.deleteStore(userId, storeId));
         assertEquals(ErrorCode.NOT_STORE_OWNER_DELETE, customException.getErrorCode());
     }
+
+    @Test
+    void deleteStore_실패_폐업한_가게를_다시_폐업하려는_경우() {
+        // given
+        Long userId = 1L;
+        User user = new User("email", "password", UserRole.OWNER, "", "");
+        ReflectionTestUtils.setField(user, "id", userId);
+        given(userRepository.getUserByUserId(userId)).willReturn(user);
+
+        Category category = new Category("한식");
+
+        Long storeId = 1L;
+        LocalTime openTime = LocalTime.parse("16:00:00");
+        LocalTime closedTime = LocalTime.parse("22:00:00");
+        Store store = new Store("김밥집", "한국", "010", openTime, closedTime, 7000L, user, category);
+        ReflectionTestUtils.setField(store, "isDeleted", true);
+        given(storeRepository.findByIdAndIsDeletedFalseOrElseThrow(storeId)).willReturn(store);
+
+        // when
+        // then
+        CustomException customException = assertThrows(CustomException.class, () -> storeService.deleteStore(userId, storeId));
+        assertEquals(ErrorCode.ALREADY_STORE_DELETED, customException.getErrorCode());
+    }
 }

--- a/src/test/java/org/example/baedalteam27/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/org/example/baedalteam27/domain/store/service/StoreServiceTest.java
@@ -337,6 +337,29 @@ class StoreServiceTest {
     }
 
     @Test
+    void updateStore_실패_가게를_등록한_사장이_아닌경우() {
+        // given
+        Long userId = 2L;
+        User user = new User("email", "password", UserRole.OWNER, "", "");
+        ReflectionTestUtils.setField(user, "id", 1L);
+
+        Long categoryId = 1L;
+        Category category = new Category("한식");
+
+        Long storeId = 1L;
+        LocalTime openTime = LocalTime.parse("16:00:00");
+        LocalTime closedTime = LocalTime.parse("22:00:00");
+        Store store = new Store("김밥집", "한국", "010", openTime, closedTime, 7000L, user, category);
+        given(storeRepository.findByIdAndIsDeletedFalseOrElseThrow(storeId)).willReturn(store);
+        UpdateStoreRequestDto updateStoreRequestDto = new UpdateStoreRequestDto("김밥집1", "한국1", "0101", openTime, closedTime, 70000L, categoryId);
+
+        // when
+        // then
+        CustomException customException = assertThrows(CustomException.class, () -> storeService.updateStore(userId, updateStoreRequestDto, storeId));
+        assertEquals(ErrorCode.NOT_STORE_OWNER_MODIFY, customException.getErrorCode());
+    }
+
+    @Test
     void deleteStore() {
     }
 }


### PR DESCRIPTION
> PR 생성 시 아래 항목을 채워주세요.
>
>
> **제목 예시:** `feat : Pull request template 작성`
>
> (✅ 작성 후 이 안내 문구는 삭제해주세요)
>

---

## 🔎 작업 내용

- CategoryService 및 StoreService test 코드 구현
- 오류코드 enum에 추가
---

## 🛠️ 변경 사항

- CategoryService 및 StoreService test 코드 구현
     - CategoryServiceTest 성공 및 실패 예외
     - StoreServiceTest 성공 및 실패 예외
- 오류 코드 추가
      - 403 인가와 관련된 코드 추가
      - 요청 및 Category, Store 관련 오류 코드 추가
---

## 🧩 트러블 슈팅

- 단위 테스트 진행(softDelete 구현)
      - Service 단위 테스트 진행이라 엔티티에서 설정한 SQLDELETE 쿼리가 실제 delete 메서드가 호출될 때 작동하지 않음
      - test 코드를 작성하면서 원본 코드는 건드리고 싶지 않아 setter 사용 X
      - 일단 test가 통과 되도록 verify()로 delete 메서드가 제대로 호출 되는지만 검증

---

## 🧯 해결해야 할 문제

- softDelete 방법 사용 시, isDeleted 필드 값을 false  ->   true 로 바꼈는지 확인하는 방법 잘 모르겠다.

---

## 📌 참고 사항

- 기타 공유하고 싶은 정보나 참고한 문서(링크 등)가 있다면 작성해주세요.

---

### 🙏 코드 리뷰 전 확인 체크리스트

- [ ]  불필요한 콘솔 로그, 주석 제거
- [ ]  커밋 메시지 컨벤션 준수 (`type : `)
- [ ]  기능 정상 동작 확인